### PR TITLE
Update 5.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spicy-lyrics",
-  "version": "5.0.2",
+  "version": "5.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spicy-lyrics",
-  "version": "5.0.2",
+  "version": "5.1.5",
   "private": false,
   "author": "Spikerko",
   "scripts": {

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -1,7 +1,3 @@
-import Animator from "@spikerko/tools/Animator";
-import BlobURLMaker from "../../utils/BlobURLMaker";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import storage from "../../utils/storage";
 import Defaults from "../Global/Defaults";
 import ArtistVisuals from "./ArtistVisuals/Main";
 import { type CoverArtCache, DynamicBackground, DynamicBackgroundOptions } from "@spikerko/tools/DynamicBackground"
@@ -12,7 +8,7 @@ const CoverArtCacheMap: CoverArtCache = new Map();
 
 export const DynamicBackgroundConfig: DynamicBackgroundOptions = {
     transition: Defaults.PrefersReducedMotion ? 0 : 0.25,
-    blur: 40,
+    blur: 65,
     speed: 0.2,
     coverArtCache: CoverArtCacheMap
 }
@@ -102,7 +98,7 @@ export default async function ApplyDynamicBackground(element: HTMLElement) {
         container.classList.add("spicy-dynamic-bg");
 
         // Set the data-cover-id attribute to match the existing code
-        container.setAttribute("data-cover-id", currentImgCover || "");
+        container.setAttribute("data-cover-id", currentImgCover ?? "");
 
         // Apply the background to the element
         currentBgInstance.AppendToElement(element);

--- a/src/components/Global/SpotifyPlayer.ts
+++ b/src/components/Global/SpotifyPlayer.ts
@@ -149,7 +149,7 @@ export const SpotifyPlayer = {
         return 0;
     },
     Seek: (position: number): void => {
-        Spicetify.Player.origin.seekTo(position);
+        Spicetify?.Player?.origin?.seekTo(position);
     },
     GetCover: (size: CoverSizes): string | undefined => {
         if (
@@ -158,32 +158,34 @@ export const SpotifyPlayer = {
             Spicetify.Player.data.item.images
         ) {
             const covers = Spicetify.Player.data.item?.images;
-            const cover = covers?.find(cover => cover.label === size) ?? undefined;
-            return cover?.url ?? "https://images.spikerko.org/SongPlaceholderFull.png";
+            if (covers.length > 0) {
+                const cover = covers?.find(cover => cover.label === size) ?? undefined;
+                return cover?.url ?? "https://images.spikerko.org/SongPlaceholderFull.png";
+            }
         }
         return "https://images.spikerko.org/SongPlaceholderFull.png";
     },
-    GetName: () => {
-        return Spicetify.Player.data.item?.name ?? undefined;
+    GetName: (): string | undefined => {
+        return Spicetify?.Player?.data?.item?.name ?? undefined;
     },
     GetAlbumName: (): string | undefined => {
-        return Spicetify.Player.data.item?.metadata.album_title ?? undefined;
+        return Spicetify?.Player?.data?.item?.metadata?.album_title ?? undefined;
     },
     GetId: (): string | undefined => {
-        return Spicetify.Player.data.item?.uri?.split(":")[2] ?? undefined;
+        return Spicetify?.Player?.data?.item?.uri?.split(":")[2] ?? undefined;
     },
     GetArtists: (): Artist[] | undefined => {
-        return Spicetify.Player.data.item?.artists as Artist[] ?? undefined;
+        return Spicetify?.Player?.data?.item?.artists as Artist[] ?? undefined;
     },
     GetUri: (): string | undefined => {
-        return Spicetify.Player.data.item?.uri ?? undefined;
+        return Spicetify?.Player?.data?.item?.uri ?? undefined;
     },
-    Pause: Spicetify.Player.pause,
-    Play: Spicetify.Player.play,
-    TogglePlayState: Spicetify.Player.togglePlay,
+    Pause: Spicetify?.Player?.pause,
+    Play: Spicetify?.Player?.play,
+    TogglePlayState: Spicetify?.Player?.togglePlay,
     Skip: {
-        Next: Spicetify.Player.next,
-        Prev: Spicetify.Player.back
+        Next: Spicetify?.Player?.next,
+        Prev: Spicetify?.Player?.back
     },
     LoopType: "none",
     ShuffleType: "none",
@@ -191,11 +193,6 @@ export const SpotifyPlayer = {
         return (
                 Spicetify.Player.data?.item?.provider &&
                 Spicetify.Player.data?.item?.provider?.startsWith("narration")
-               ) ||
-               (
-                Spicetify.Player.data?.item?.artists &&
-                Spicetify.Player.data?.item?.artists?.length > 0 &&
-                Spicetify.Player.data?.item?.artists[0].name.includes("DJ")
                ) || (
                 Spicetify.Player.data?.restrictions?.disallowSeekingReasons &&
                 Spicetify.Player.data?.restrictions?.disallowSeekingReasons?.length > 0 &&
@@ -206,6 +203,6 @@ export const SpotifyPlayer = {
                 Spicetify.Player.data?.item?.type === "unknown"
                ) ? true : false;
     },
-    IsLiked: () => Spicetify.Player.getHeart(),
-    ToggleLike: () => Spicetify.Player.toggleHeart(),
+    IsLiked: () => Spicetify?.Player?.getHeart(),
+    ToggleLike: () => Spicetify?.Player?.toggleHeart(),
 };

--- a/src/components/Utils/CompactMode.ts
+++ b/src/components/Utils/CompactMode.ts
@@ -1,3 +1,4 @@
+import { GetCurrentLyricsContainerInstance } from "../../utils/Lyrics/Applyer/CreateLyricsContainer";
 import Fullscreen from "./Fullscreen";
 import { Session_NowBar_SetSide } from "./NowBar";
 
@@ -14,6 +15,7 @@ export const EnableCompactMode = () => {
     NowBar.classList.add("LeftSide");
     NowBar.classList.remove("RightSide");
     CompactMode = true;
+    GetCurrentLyricsContainerInstance()?.Resize();
 }
 
 export const DisableCompactMode = () => {
@@ -22,6 +24,7 @@ export const DisableCompactMode = () => {
     SpicyLyricsPage.classList.remove("CompactMode");
     Session_NowBar_SetSide();
     CompactMode = false;
+    GetCurrentLyricsContainerInstance()?.Resize();
 }
 
 export const IsCompactMode = () => {

--- a/src/components/Utils/NowBar.ts
+++ b/src/components/Utils/NowBar.ts
@@ -10,6 +10,7 @@ import { QueueForceScroll, ResetLastLine } from '../../utils/Scrolling/ScrollToA
 import { Maid } from '@socali/modules/Maid';
 import { Interval } from '@socali/modules/Scheduler';
 import BlobURLMaker from "../../utils/BlobURLMaker";
+import { GetCurrentLyricsContainerInstance } from '../../utils/Lyrics/Applyer/CreateLyricsContainer';
 
 // Define interfaces for our control instances
 interface PlaybackControlsInstance {
@@ -775,6 +776,7 @@ function OpenNowBar(skipSaving: boolean = false) {
     } */
     NowBarObj.Open = true;
     PageView.AppendViewControls(true);
+    GetCurrentLyricsContainerInstance()?.Resize();
     QueueForceScroll();
 }
 
@@ -837,6 +839,7 @@ function CloseNowBar() {
     }
 
     PageView.AppendViewControls(true);
+    GetCurrentLyricsContainerInstance()?.Resize();
     QueueForceScroll();
 }
 

--- a/src/css/ContentBox.css
+++ b/src/css/ContentBox.css
@@ -651,13 +651,13 @@
     width: calc(30cqh * .25);
 }
 
-#SpicyLyricsPage .ContentBox .NowBar.Active:is(.LeftSide) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .simplebar-content,
-#SpicyLyricsPage .ContentBox .NowBar:not(.Active) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .simplebar-content {
+#SpicyLyricsPage .ContentBox .NowBar.Active:is(.LeftSide) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .SpicyLyricsScrollContainer,
+#SpicyLyricsPage .ContentBox .NowBar:not(.Active) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .SpicyLyricsScrollContainer {
     padding-left: var(--LyricsLeftSidePadding) !important;
     padding-right: var(--LyricsRightSidePadding) !important;
 }
 
-#SpicyLyricsPage .ContentBox .NowBar.Active:is(.RightSide) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .simplebar-content {
+#SpicyLyricsPage .ContentBox .NowBar.Active:is(.RightSide) + .LyricsContainer .LyricsContent .simplebar-content-wrapper .SpicyLyricsScrollContainer {
     padding-right: var(--LyricsLeftSidePadding) !important;
     padding-left: calc(var(--LyricsRightSidePadding) * 1.45) !important;
 }
@@ -757,11 +757,12 @@
 }
 
 #SpicyLyricsPage.Fullscreen.CompactMode .ContentBox .LyricsContainer {
-    padding-top: 21cqh;
-    transition: padding-top .4s;
+    position: relative;
+    top: 21cqh;
+    transition: top .4s;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent .simplebar-content-wrapper .simplebar-content {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent .simplebar-content-wrapper .SpicyLyricsScrollContainer {
     padding-top: 5cqh !important;
 }
 
@@ -782,24 +783,25 @@
     display: none !important;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent .TopSpacer {
-    height: 0 !important;
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer {
+    margin-top: 0 !important;
+    margin-bottom: 64cqh !important;
 }
 
 #SpicyLyricsPage.Fullscreen.CompactMode .ContentBox .NowBar:has(.CenteredView .Header .MediaBox:hover) {
     height: calc(var(--Compact_NowBarHeight) + 40cqw);
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent .BottomSpacer {
-    height: 64vh !important;
-}
-
 #SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent {
     --DefaultLyricsSize: clamp(3rem, calc(1cqw* 7), 4rem);
 }
 
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent {
+    --DefaultLyricsSize: clamp(2.5rem, calc(1cqw* 7), 3.5rem);
+}
+
 #SpicyLyricsPage.Fullscreen.CompactMode:has(.MediaBox:hover) .ContentBox .LyricsContainer {
-    padding-top: calc(var(--Compact_NowBarHeight) + 50cqw);
+    top: calc(var(--Compact_NowBarHeight) + 50cqw);
 }
 
 #SpicyLyricsPage.Fullscreen.CompactMode .ContentBox .NowBar .CenteredView .Header:has(.MediaBox:hover) .Metadata {
@@ -811,26 +813,41 @@
     padding: 0 0 10cqh !important;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl),
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
   padding-left: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl),
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
   padding-right: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned,
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
   padding-right: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned),
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
   padding-left: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line,
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
   padding-right: 2cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
+#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl,
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
   padding-left: 2cqw;
+}
+
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent {
+    --LyricsLeftSidePadding: 13.5cqw;
+    --LyricsRightSidePadding: 11.5cqw;
+}
+
+#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent .TopSpacer {
+    height: 9.5vh !important;
 }

--- a/src/css/DynamicBG/spicy-dynamic-bg.css
+++ b/src/css/DynamicBG/spicy-dynamic-bg.css
@@ -8,7 +8,7 @@
   top: 0;
   width: 100%;
   transform-origin: center center;
-  filter: brightness(0.65) saturate(2.5);
+  filter: brightness(0.55) saturate(2.65);
 }
 
 .spicy-dynamic-bg {
@@ -22,17 +22,17 @@
 }
 
 /* Special styling for side panel */
-.spicy-dynamic-bg-in-this:is(aside) .spicy-dynamic-bg {
+aside .spicy-dynamic-bg {
   max-height: 100%;
   max-width: 100%;
 }
 
-.spicy-dynamic-bg-in-this:is(aside) .spicy-dynamic-bg {
-  filter: brightness(0.8) saturate(1.5);
+aside .spicy-dynamic-bg {
+  filter: brightness(0.6) saturate(2.65);
 }
 
 /* Video element styling */
-.spicy-dynamic-bg-in-this:is(aside) video {
+aside:has(.spicy-dynamic-bg) video {
   filter: opacity(0.8) brightness(.85);
   -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
@@ -50,8 +50,8 @@
   display: none;
 }
 
-.spicy-dynamic-bg-in-this:is(aside) .AAdBM1nhG73supMfnYX7 {
-  z-index: 10;
+aside:has(.spicy-dynamic-bg) .AAdBM1nhG73supMfnYX7 {
+  z-index: 1;
   position: relative;
 }
 
@@ -73,4 +73,9 @@
 /* Hide sidebar background when in fullscreen lyrics mode */
 body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar aside:is(.NowPlayingView, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg {
   display: none;
+}
+
+
+.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.spicy-dynamic-bg) .main-buddyFeed-scrollBarContainer {
+  z-index: 1;
 }

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -1,5 +1,5 @@
 :root {
-  --SpicyLyrics-LineSpacing: 2cqw 0;
+  --SpicyLyrics-LineSpacing: 1cqw 0;
 }
 
 #SpicyLyricsPage .LyricsContainer .LyricsContent.HideLineBlur .line {
@@ -38,7 +38,8 @@
 
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active,
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letter {
+#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letter,
+#SpicyLyricsPage .LyricsContainer .LyricsContent .line.static {
   background-image:
       linear-gradient(var(--gradient-degrees),
         rgba(255,255,255,var(--gradient-alpha))
@@ -55,7 +56,7 @@
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung,
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .word,
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Static"] .line {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
   text-shadow: 0 0 var(--BlurAmount,0) rgba(var(--gradient-color),var(--gradient-color),var(--gradient-color),var(--gradient-alpha));
 }
 
@@ -261,13 +262,13 @@
   position: relative;
   transform-origin: center center !important;
   font-family: SpicyLyrics !important;
-  margin: -4.5cqw 0 !important;
+  margin: -3.65cqw 0 !important;
   z-index: -1;
 }
 
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line.Active {
   z-index: auto;
-  margin: -1.38cqw 0 !important;
+  margin: -1cqw 0 !important;
 }
 
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
@@ -346,7 +347,7 @@
 }
 
 #SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.musical-line) {
-  margin: var(--SpicyLyrics-LineSpacing, 2cqw 0);
+  margin: var(--SpicyLyrics-LineSpacing, 1cqw 0);
 /*   margin-left: 18cqw;
   margin-right: 30cqw; */
 }
@@ -360,7 +361,7 @@
   --font-size: calc(var(--DefaultLyricsSize)*0.47);
   font-size: var(--font-size);
   opacity: 0.75;
-  margin: 3cqw 0 0 !important;
+  margin: 1cqw 0 0 !important;
   scale: 1;
   transition: color 0.5s ease-in-out !important;
 }
@@ -369,7 +370,7 @@
   color: white;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Line"] .line {
+#SpicyLyricsPage .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line {
   --text-shadow-blur-radius: 4px;
   --text-shadow-opacity: 0%;
   transform-origin: left center;
@@ -378,25 +379,25 @@
 /*   text-shadow: 0 0 var(--text-shadow-blur-radius) rgba(255,255,255,var(--text-shadow-opacity)); */
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Line"] .line:not(.Active) {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line:not(.Active) {
   --text-shadow-blur-radius: 4px !important;
   --text-shadow-opacity: 0% !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Line"] .line.OppositeAligned {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.OppositeAligned {
   transform-origin: right center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
   scale: 1.05;
   /* text-shadow: var(--ActiveTextGlowDef) !important; */
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Static"] {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] {
   --DefaultLyricsSize: clamp(0.8rem,calc(1cqw* 5), 2.5rem);
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent[data-lyrics-type="Static"] .line {
+#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
   font-weight: 500;
 }
 

--- a/src/css/Lyrics/main.css
+++ b/src/css/Lyrics/main.css
@@ -52,11 +52,17 @@
   opacity: 0;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .simplebar-content {
+#SpicyLyricsPage .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer {
   container-type: size !important;
+  width: 100cqw;
   transition: padding-right .4s, padding-left .4s;
+  display: flex;
+  flex-direction: column;
+  
+  margin-bottom: 45cqh;
+  margin-top: 25cqh;
 }
-
+/* 
 #SpicyLyricsPage .LyricsContainer .LyricsContent .BottomSpacer {
   display: block;
   height: 45vh;
@@ -68,3 +74,4 @@
   height: 20vh;
   width: 100%;
 }
+ */

--- a/src/css/default.css
+++ b/src/css/default.css
@@ -18,7 +18,6 @@
   top: 0;
   width: 100%;
   font-weight: 700;
-  z-index: 99;
   user-select: none;
   -webkit-user-drag: none;
 }
@@ -28,10 +27,10 @@
   font-family: SpicyLyrics, "Noto Sans Georgian", "VazirmatnRegular";
 }
 
-body:has(#SpicyLyricsPage) .main-view-container__scroll-node-child,
-body:has(#SpicyLyricsPage) .main-view-container__scroll-node-child-spacer,
-body:has(#SpicyLyricsPage) .main-view-container__scroll-node-child,
-body:has(#SpicyLyricsPage) .main-view-container__scroll-node-child-spacer {
+.Root__main-view:has(#SpicyLyricsPage) .main-view-container__scroll-node-child,
+.Root__main-view:has(#SpicyLyricsPage) .main-view-container__scroll-node-child-spacer,
+.Root__main-view:has(#SpicyLyricsPage) .main-view-container__scroll-node-child,
+.Root__main-view:has(#SpicyLyricsPage) .main-view-container__scroll-node-child-spacer {
   display: none;
 }
 

--- a/src/utils/Addons.ts
+++ b/src/utils/Addons.ts
@@ -34,6 +34,17 @@ function BOTTOM_ApplyLyricsSpacer(Container: HTMLElement) {
     Container.appendChild(div);
 }
 
+
+function GetContainerHeight(Container: HTMLElement) {
+    Container.style.height = "0px";
+    return Container.scrollHeight;
+    /* const style = globalThis.getComputedStyle(Container)
+    const marginTop = parseFloat(style.marginTop)
+    const marginBottom = parseFloat(style.marginBottom)
+
+    return (Container.scrollHeight + marginTop + marginBottom) */
+}
+
 export const ArabicPersianRegex = /[\u0600-\u06FF]/;
 
-export { DeepFreeze, IsPlaying, TOP_ApplyLyricsSpacer, BOTTOM_ApplyLyricsSpacer }
+export { DeepFreeze, IsPlaying, TOP_ApplyLyricsSpacer, BOTTOM_ApplyLyricsSpacer, GetContainerHeight }

--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -87,7 +87,7 @@ export default function GetProgress() {
 
   // Calculate and return the current track position
   const FinalPosition = (Position + deltaTime)
-  return isLocallyPlaying ? FinalPosition : (FinalPosition + Global.NonLocalTimeOffset) ;
+  return FinalPosition + 85;
 }
 
 

--- a/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
+++ b/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
@@ -1,0 +1,86 @@
+import { GetContainerHeight } from "../../Addons";
+import { QueueForceScroll } from "../../Scrolling/ScrollToActiveLine";
+import { ScrollSimplebar } from "../../Scrolling/Simplebar/ScrollSimplebar";
+
+type LyricsContainerReturnObject = {
+    Container: HTMLElement;
+    ResizeListener: ResizeObserver;
+    Append: (AppendTo: HTMLElement) => void;
+    Remove: () => void;
+    Resize: () => void;
+};
+
+const LyricsContainerInstances = new Map<number, LyricsContainerReturnObject>();
+
+let lastMapIndex = -1;
+
+const CreateLyricsContainer = (): LyricsContainerReturnObject => {
+    const Container = document.createElement("div");
+    Container.classList.add("SpicyLyricsScrollContainer");
+
+    const Resize = () => {
+        Container.style.height = `0px`;
+        setTimeout(() => {
+            const Height = GetContainerHeight(Container);
+            Container.style.height = `${Height}px`;
+            setTimeout(() => ScrollSimplebar?.recalculate(), 100)
+            setTimeout(() => {
+                Container.style.height = `0px`;
+                setTimeout(() => {
+                    const Height = GetContainerHeight(Container);
+                    Container.style.height = `${Height}px`;
+                    setTimeout(() => ScrollSimplebar?.recalculate(), 100)
+                    QueueForceScroll();
+                }, 110)
+            }, 50)
+        }, 150)
+    }
+
+    const ResizeListener = new ResizeObserver(() => {
+        Resize();
+    });
+
+    const Remove = () => {
+        ResizeListener.unobserve(Container.parentElement as HTMLElement);
+        ResizeListener.disconnect();
+        Container.remove();
+        LyricsContainerInstances.delete(lastMapIndex)
+    };
+
+    const ReturnObject = {
+        Container,
+        ResizeListener,
+        Append: (AppendTo: HTMLElement) => {
+            AppendTo.appendChild(Container);
+            Container.style.height = `${GetContainerHeight(Container)}px`;
+            ResizeListener.observe(Container.parentElement as HTMLElement);
+        },
+        Remove,
+        Resize
+    };
+
+    lastMapIndex += 1;
+
+    LyricsContainerInstances.set(lastMapIndex, ReturnObject)
+
+    return ReturnObject;
+}
+
+const GetCurrentLyricsContainerInstance = (): LyricsContainerReturnObject | undefined => {
+    let currentInstance: LyricsContainerReturnObject | undefined = undefined;
+    LyricsContainerInstances.forEach((ReturnObject, index, array) => {
+        const isLast = array.size - 1 === index;
+        if (isLast) {
+            currentInstance = ReturnObject;
+        }
+    })
+    return currentInstance ?? undefined;
+}
+
+const DestroyAllLyricsContainers = () => {
+    LyricsContainerInstances.forEach(Instance => {
+        Instance.Remove();
+    })
+}
+
+export { CreateLyricsContainer, DestroyAllLyricsContainers, GetCurrentLyricsContainerInstance }

--- a/src/utils/Lyrics/Applyer/Credits/ApplyLyricsCredits.ts
+++ b/src/utils/Lyrics/Applyer/Credits/ApplyLyricsCredits.ts
@@ -6,8 +6,7 @@ interface LyricsData {
     styles?: Record<string, string>;
 }
 
-export function ApplyLyricsCredits(data: LyricsData): void {
-    const LyricsContainer = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+export function ApplyLyricsCredits(data: LyricsData, LyricsContainer: HTMLElement): void {
     if (!data?.SongWriters || !LyricsContainer) return;
 
     const CreditsElement = document.createElement("div");

--- a/src/utils/Lyrics/Applyer/Static.ts
+++ b/src/utils/Lyrics/Applyer/Static.ts
@@ -1,4 +1,3 @@
-import { BOTTOM_ApplyLyricsSpacer, TOP_ApplyLyricsSpacer } from "../../Addons";
 import Defaults from "../../../components/Global/Defaults";
 import { applyStyles, removeAllStyles, StyleProperties } from "../../CSS/Styles";
 import { ClearScrollSimplebar, MountScrollSimplebar, RecalculateScrollSimplebar, ScrollSimplebar } from "../../Scrolling/Simplebar/ScrollSimplebar";
@@ -7,6 +6,7 @@ import { ApplyLyricsCredits } from "./Credits/ApplyLyricsCredits";
 import isRtl from "../isRtl";
 import { ClearLyricsPageContainer } from "../fetchLyrics";
 import { EmitApply, EmitNotApplyed } from "./OnApply";
+import { CreateLyricsContainer, DestroyAllLyricsContainers } from "./CreateLyricsContainer";
 
 /**
  * Interface for static lyrics data
@@ -30,7 +30,12 @@ export function ApplyStaticLyrics(data: StaticLyricsData): void {
     if (!Defaults.LyricsContainerExists) return;
 
     EmitNotApplyed();
-    const LyricsContainer = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+
+    DestroyAllLyricsContainers();
+
+    const LyricsContainerParent = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+    const LyricsContainerInstance = CreateLyricsContainer();
+    const LyricsContainer = LyricsContainerInstance.Container;
 
     if (!LyricsContainer) {
         console.error("Cannot apply static lyrics: LyricsContainer not found");
@@ -42,8 +47,6 @@ export function ApplyStaticLyrics(data: StaticLyricsData): void {
     ClearLyricsContentArrays();
     ClearScrollSimplebar();
     ClearLyricsPageContainer();
-
-    TOP_ApplyLyricsSpacer(LyricsContainer);
 
     data.Lines.forEach(line => {
         const lineElem = document.createElement("div");
@@ -71,8 +74,11 @@ export function ApplyStaticLyrics(data: StaticLyricsData): void {
         LyricsContainer.appendChild(lineElem);
     });
 
-    ApplyLyricsCredits(data);
-    BOTTOM_ApplyLyricsSpacer(LyricsContainer);
+    ApplyLyricsCredits(data, LyricsContainer);
+
+    if (LyricsContainerParent) {
+        LyricsContainerInstance.Append(LyricsContainerParent);
+    }
 
     // Handle scrollbar
     if (ScrollSimplebar) {
@@ -99,6 +105,8 @@ export function ApplyStaticLyrics(data: StaticLyricsData): void {
             applyStyles(LyricsStylingContainer, data.styles);
         }
     }
+
+
 
     EmitApply(data.Type, data.Content);
 }

--- a/src/utils/Lyrics/Applyer/Synced/Line.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Line.ts
@@ -1,4 +1,3 @@
-import { BOTTOM_ApplyLyricsSpacer, TOP_ApplyLyricsSpacer } from "../../../Addons";
 import Defaults from "../../../../components/Global/Defaults";
 import { applyStyles, removeAllStyles } from "../../../CSS/Styles";
 import { ClearScrollSimplebar, MountScrollSimplebar, RecalculateScrollSimplebar, ScrollSimplebar } from "../../../Scrolling/Simplebar/ScrollSimplebar";
@@ -8,6 +7,7 @@ import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits";
 import isRtl from "../../isRtl";
 import { ClearLyricsPageContainer } from "../../fetchLyrics";
 import { EmitApply, EmitNotApplyed } from "../OnApply";
+import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer";
 
 // Define the data structure for lyrics
 interface LyricsLineData {
@@ -26,10 +26,16 @@ interface LyricsData {
   styles?: Record<string, string>;
 }
 
+
 export function ApplyLineLyrics(data: LyricsData): void {
     if (!Defaults.LyricsContainerExists) return;
     EmitNotApplyed();
-    const LyricsContainer = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+
+    DestroyAllLyricsContainers();
+
+    const LyricsContainerParent = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+    const LyricsContainerInstance = CreateLyricsContainer();
+    const LyricsContainer = LyricsContainerInstance.Container;
 
     // Check if LyricsContainer exists
     if (!LyricsContainer) {
@@ -45,7 +51,6 @@ export function ApplyLineLyrics(data: LyricsData): void {
 
     ClearLyricsPageContainer();
 
-    TOP_ApplyLyricsSpacer(LyricsContainer);
 
     if (data.StartTime >= lyricsBetweenShow) {
         const musicalLine = document.createElement("div")
@@ -239,9 +244,12 @@ export function ApplyLineLyrics(data: LyricsData): void {
         }
     })
 
-   ApplyLyricsCredits(data);
+   ApplyLyricsCredits(data, LyricsContainer);
 
-   BOTTOM_ApplyLyricsSpacer(LyricsContainer)
+   
+  if (LyricsContainerParent) {
+    LyricsContainerInstance.Append(LyricsContainerParent);
+  }
 
    if (ScrollSimplebar) RecalculateScrollSimplebar();
     else MountScrollSimplebar();
@@ -262,6 +270,7 @@ export function ApplyLineLyrics(data: LyricsData): void {
   } else {
     console.warn("LyricsStylingContainer not found");
   }
+
 
   EmitApply(data.Type, data.Content)
 }

--- a/src/utils/Lyrics/Applyer/Synced/Syllable.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Syllable.ts
@@ -1,4 +1,3 @@
-import { BOTTOM_ApplyLyricsSpacer, TOP_ApplyLyricsSpacer } from "../../../Addons";
 import Defaults from "../../../../components/Global/Defaults";
 import { applyStyles, removeAllStyles } from "../../../CSS/Styles";
 import { ClearScrollSimplebar, MountScrollSimplebar, RecalculateScrollSimplebar, ScrollSimplebar } from "../../../Scrolling/Simplebar/ScrollSimplebar";
@@ -11,6 +10,7 @@ import { IdleEmphasisLyricsScale, IdleLyricsScale } from "../../Animator/Shared"
 import isRtl from '../../isRtl';
 import { ClearLyricsPageContainer } from '../../fetchLyrics';
 import { EmitApply, EmitNotApplyed } from '../OnApply';
+import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer";
 
 // Define the data structure for syllable lyrics
 interface SyllableData {
@@ -50,7 +50,11 @@ interface LyricsData {
 export function ApplySyllableLyrics(data: LyricsData): void {
   if (!Defaults.LyricsContainerExists) return;
   EmitNotApplyed();
-  const LyricsContainer = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+
+  DestroyAllLyricsContainers();
+  const LyricsContainerParent = document.querySelector<HTMLElement>("#SpicyLyricsPage .LyricsContainer .LyricsContent");
+  const LyricsContainerInstance = CreateLyricsContainer();
+  const LyricsContainer = LyricsContainerInstance.Container;
 
   // Check if LyricsContainer exists
   if (!LyricsContainer) {
@@ -64,8 +68,7 @@ export function ApplySyllableLyrics(data: LyricsData): void {
   ClearScrollSimplebar();
 
   ClearLyricsPageContainer();
-
-  TOP_ApplyLyricsSpacer(LyricsContainer);
+  
   if (data.StartTime >= lyricsBetweenShow) {
     const musicalLine = document.createElement("div")
     musicalLine.classList.add("line")
@@ -407,9 +410,11 @@ export function ApplySyllableLyrics(data: LyricsData): void {
         }
   });
 
-  ApplyLyricsCredits(data);
-
-  BOTTOM_ApplyLyricsSpacer(LyricsContainer)
+  ApplyLyricsCredits(data, LyricsContainer);
+  
+  if (LyricsContainerParent) {
+    LyricsContainerInstance.Append(LyricsContainerParent);
+  }
 
   if (ScrollSimplebar) RecalculateScrollSimplebar();
     else MountScrollSimplebar();

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -176,7 +176,7 @@ export default async function fetchLyrics(uri: string) {
 
 
         if (LyricsStore) {
-            const expiresAt = new Date().getTime() + 1000 * 60 * 60 * 24 * 7; // Expire after 7 days
+            //const expiresAt = new Date().getTime() + 1000 * 60 * 60 * 24 * 7; // Expire after 7 days
 
             try {
                 await LyricsStore.SetItem(trackId, lyricsJson);
@@ -281,7 +281,7 @@ async function noLyricsMessage(Cache = true, LocalStorage = true) {
     }
 
     if (LyricsStore && Cache && trackId) {
-        const expiresAt = new Date().getTime() + 1000 * 60 * 60 * 24 * 7; // Expire after 7 days
+        //const expiresAt = new Date().getTime() + 1000 * 60 * 60 * 24 * 7; // Expire after 7 days
 
         try {
             await LyricsStore.SetItem(trackId, "NO_LYRICS");
@@ -309,12 +309,6 @@ async function noLyricsMessage(Cache = true, LocalStorage = true) {
     return {
         Type: "Static",
         id: SpotifyPlayer.GetId() ?? '',
-        styles: {
-            display: "flex",
-            "align-items": "center",
-            "justify-content": "center",
-            "flex-direction": "column"
-        },
         Lines: [
             {
                 Text: "No Lyrics Found"

--- a/src/utils/Lyrics/lyrics.ts
+++ b/src/utils/Lyrics/lyrics.ts
@@ -212,11 +212,11 @@ function LinesEvListener(e: MouseEvent) {
             word.Letters.forEach((letter) => {
               if (letter.HTMLElement === target) {
                 startTime = line.StartTime;
+                if (array.length > 0) {
+                  startTime = array[0].StartTime;
+                }
               }
             });
-          }
-          if (array.length > 0) {
-            startTime = array[0].StartTime;
           }
         });
       }

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -132,11 +132,11 @@ const GetScrollLine = (Lines:  LyricsLine[] | LyricsSyllable[], ProcessedPositio
 
 const ScrollTo = (container: HTMLElement, element: HTMLElement, instantScroll: boolean = false, type: "Center" | "Top" = "Center") => {
     if (type === "Center") {
-        ScrollIntoCenterViewCSS(container, element, -50, instantScroll);
+        ScrollIntoCenterViewCSS(container, element, -30, instantScroll);
     } else if (type === "Top") {
         ScrollIntoTopViewCSS(container, element, 85, instantScroll);
     }
-}
+};
 
 let scrolledToLastLine = false;
 let scrolledToFirstLine = false;
@@ -178,7 +178,7 @@ export function ScrollToActiveLine(ScrollSimplebar: SimpleBar) {
             const scrollToLine = allLinesSung ? Lines[Lines.length - 1]?.HTMLElement : currentLine?.HTMLElement;
             if (!scrollToLine) return
             lastLine = scrollToLine;
-            ScrollTo(container, scrollToLine, true, GetScrollType());
+            ScrollTo(container, scrollToLine, (wasDrasticPositionChange(lastPosition ?? 0, Position) ? false : true), GetScrollType());
             if (forceScrollQueued) {
                 forceScrollQueued = false; // Reset the queue after using it
             }


### PR DESCRIPTION
# Update 5.1.5
- Fixed "choppy" scroll animations
- Added *almost FULL* compatibility to Spicy Lyrics
  - Spicy Lyrics should be available on most - new *AND* old versions of Spotify
  - Also the "Non-Scrolling" bug has been fully fixed
- Most DJ Issues should be fixed in this update
- Increased Background blur
- Changed Saturation and Brightness of all possible Dynamic BGs
- Changed Scroll offset
- NowBar -> MediaBox Elements now show "by half" on Page Mousemove, instead of NowBar Mousemove