### PR TITLE
Fix Local Song Album Cover for NowBar

### DIFF
--- a/src/components/Utils/NowBar.ts
+++ b/src/components/Utils/NowBar.ts
@@ -882,9 +882,10 @@ function UpdateNowBar(force = false) {
         MediaImage.classList.add("Skeletoned");
         const finalUrl = `https://i.scdn.co/image/${coverArt.replace("spotify:image:", "")}`;
         BlobURLMaker(finalUrl)
+        .catch(() => null)
         .then(coverArtUrl => {
             MediaImage.classList.remove("Skeletoned")
-            MediaImage.style.backgroundImage = `url("${coverArtUrl ?? finalUrl}")`;
+            MediaImage.style.backgroundImage = `url("${coverArtUrl ?? coverArt}")`;
             MediaImage.setAttribute("last-image", coverArt ?? "");
         })
     }


### PR DESCRIPTION
As far as I know, fetching a Spotify URI isn't possible, so if generating a Blob gives an error, fallback with the original album cover URI, `spotify:localfileimage:something`