### PR TITLE
Update 5.11.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,14 +4,17 @@
     "release": "deno run -A ./tasks/release.ts"
   },
   "imports": {
+    "@applemusic-like-lyrics/core": "npm:@applemusic-like-lyrics/core@^0.1.3",
     "@socali/modules": "jsr:@socali/modules@^4.4.1",
-    "@spicetify/bundler": "jsr:@spicetify/bundler@^1.0.7",
+    "@spicetify/bundler": "jsr:@spicetify/bundler@^1.1.9",
     "@spikerko/tools": "jsr:@spikerko/tools@^1.5.6",
-    "@spikerko/web-modules": "jsr:@spikerko/web-modules@^1.0.5"
+    "@spikerko/web-modules": "jsr:@spikerko/web-modules@^1.0.5",
+    "fast-xml-parser": "npm:fast-xml-parser@^5.2.5"
   },
   "compilerOptions": {
     "lib": ["deno.window", "dom", "es2020"],
     "strict": false,
     "jsx": "react"
-  }
+  },
+  "nodeModulesDir": "auto"
 }

--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "jsr:@codemonument/cliffy@1.0.0-rc.3": "1.0.0-rc.3",
     "jsr:@luca/esbuild-deno-loader@0.11.1": "0.11.1",
     "jsr:@socali/modules@^4.4.1": "4.4.1",
-    "jsr:@spicetify/bundler@^1.0.7": "1.0.7",
+    "jsr:@spicetify/bundler@^1.1.9": "1.1.9",
     "jsr:@spikerko/tools@^1.5.6": "1.5.6",
     "jsr:@spikerko/web-modules@^1.0.5": "1.0.5",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
@@ -15,6 +15,7 @@
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/path@1.1.2": "1.1.2",
     "jsr:@std/path@^1.0.6": "1.1.2",
+    "npm:@applemusic-like-lyrics/core@~0.1.3": "0.1.3_@pixi+app@7.4.3__@pixi+core@7.4.3__@pixi+display@7.4.3___@pixi+core@7.4.3_@pixi+core@7.4.3_@pixi+display@7.4.3__@pixi+core@7.4.3_@pixi+filter-blur@7.4.3__@pixi+core@7.4.3_@pixi+filter-bulge-pinch@5.1.1__@pixi+core@7.4.3_@pixi+filter-color-matrix@7.4.3__@pixi+core@7.4.3_@pixi+sprite@7.4.3__@pixi+core@7.4.3__@pixi+display@7.4.3___@pixi+core@7.4.3_jss@10.10.0_jss-preset-default@10.10.0",
     "npm:autoprefixer@10.4.21": "10.4.21_postcss@8.5.6",
     "npm:chalk@5.6.0": "5.6.0",
     "npm:cssnano-preset-advanced@7.0.9": "7.0.9_postcss@8.5.6",
@@ -23,6 +24,7 @@
     "npm:cyrillic-romanization@*": "1.1.8",
     "npm:d3-ease@*": "3.0.1",
     "npm:esbuild@0.25.9": "0.25.9",
+    "npm:fast-xml-parser@^5.2.5": "5.2.5",
     "npm:franc-all@*": "7.2.0",
     "npm:kuroshiro@*": "1.2.0",
     "npm:langs@*": "2.0.0",
@@ -55,8 +57,8 @@
     "@socali/modules@4.4.1": {
       "integrity": "1a8ae6eb7279ba223413386ab72366512b1ad78503d370643d820b42cac9e966"
     },
-    "@spicetify/bundler@1.0.7": {
-      "integrity": "93ebce152e03c97a142def32fae2cca6a3a85277dc3093cdd5d8b6d3cd65324c",
+    "@spicetify/bundler@1.1.9": {
+      "integrity": "b1495b7c1cd419eb0637262ad31706efa06386b2eba3d45b69801fbe72193706",
       "dependencies": [
         "jsr:@codemonument/cliffy",
         "jsr:@luca/esbuild-deno-loader",
@@ -105,6 +107,21 @@
     }
   },
   "npm": {
+    "@applemusic-like-lyrics/core@0.1.3_@pixi+app@7.4.3__@pixi+core@7.4.3__@pixi+display@7.4.3___@pixi+core@7.4.3_@pixi+core@7.4.3_@pixi+display@7.4.3__@pixi+core@7.4.3_@pixi+filter-blur@7.4.3__@pixi+core@7.4.3_@pixi+filter-bulge-pinch@5.1.1__@pixi+core@7.4.3_@pixi+filter-color-matrix@7.4.3__@pixi+core@7.4.3_@pixi+sprite@7.4.3__@pixi+core@7.4.3__@pixi+display@7.4.3___@pixi+core@7.4.3_jss@10.10.0_jss-preset-default@10.10.0": {
+      "integrity": "sha512-QCT280bl7zr0Dw7uXH22d7NGNRKfP0MisCL8U639BpFep9WpKbd1CwTnX8smE7D3KliIN8QC+6hYZrpRUyPy0Q==",
+      "dependencies": [
+        "@pixi/app",
+        "@pixi/core",
+        "@pixi/display",
+        "@pixi/filter-blur",
+        "@pixi/filter-bulge-pinch",
+        "@pixi/filter-color-matrix",
+        "@pixi/sprite",
+        "bezier-easing",
+        "jss",
+        "jss-preset-default"
+      ]
+    },
     "@babel/runtime@7.28.3": {
       "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
     },
@@ -355,8 +372,114 @@
       ],
       "scripts": true
     },
+    "@pixi/app@7.4.3_@pixi+core@7.4.3_@pixi+display@7.4.3__@pixi+core@7.4.3": {
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "dependencies": [
+        "@pixi/core",
+        "@pixi/display"
+      ]
+    },
+    "@pixi/color@7.4.3": {
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "dependencies": [
+        "@pixi/colord"
+      ]
+    },
+    "@pixi/colord@2.9.6": {
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+    },
+    "@pixi/constants@7.4.3": {
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ=="
+    },
+    "@pixi/core@7.4.3": {
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "dependencies": [
+        "@pixi/color",
+        "@pixi/constants",
+        "@pixi/extensions",
+        "@pixi/math",
+        "@pixi/runner",
+        "@pixi/settings",
+        "@pixi/ticker",
+        "@pixi/utils"
+      ]
+    },
+    "@pixi/display@7.4.3_@pixi+core@7.4.3": {
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "dependencies": [
+        "@pixi/core"
+      ]
+    },
+    "@pixi/extensions@7.4.3": {
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw=="
+    },
+    "@pixi/filter-blur@7.4.3_@pixi+core@7.4.3": {
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "dependencies": [
+        "@pixi/core"
+      ]
+    },
+    "@pixi/filter-bulge-pinch@5.1.1_@pixi+core@7.4.3": {
+      "integrity": "sha512-80I3g813td7Fnzi7IJSiR3z8gZlKblk6WN+5z6WnscQROcNEpck6lgWS/Lf/IdeHB/FtUKJCbx7RzxkUhiRTvA==",
+      "dependencies": [
+        "@pixi/core"
+      ]
+    },
+    "@pixi/filter-color-matrix@7.4.3_@pixi+core@7.4.3": {
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "dependencies": [
+        "@pixi/core"
+      ]
+    },
+    "@pixi/math@7.4.3": {
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw=="
+    },
+    "@pixi/runner@7.4.3": {
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw=="
+    },
+    "@pixi/settings@7.4.3": {
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "dependencies": [
+        "@pixi/constants",
+        "@types/css-font-loading-module",
+        "ismobilejs"
+      ]
+    },
+    "@pixi/sprite@7.4.3_@pixi+core@7.4.3_@pixi+display@7.4.3__@pixi+core@7.4.3": {
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "dependencies": [
+        "@pixi/core",
+        "@pixi/display"
+      ]
+    },
+    "@pixi/ticker@7.4.3": {
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "dependencies": [
+        "@pixi/extensions",
+        "@pixi/settings",
+        "@pixi/utils"
+      ]
+    },
+    "@pixi/utils@7.4.3": {
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "dependencies": [
+        "@pixi/color",
+        "@pixi/constants",
+        "@pixi/settings",
+        "@types/earcut",
+        "earcut",
+        "eventemitter3",
+        "url"
+      ]
+    },
     "@socket.io/component-emitter@3.1.2": {
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "@types/css-font-loading-module@0.0.12": {
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
+    },
+    "@types/earcut@2.1.4": {
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
     },
     "acorn@8.15.0": {
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
@@ -378,6 +501,9 @@
       ],
       "bin": true
     },
+    "bezier-easing@2.1.0": {
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig=="
+    },
     "boolbase@1.0.0": {
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
@@ -387,8 +513,8 @@
         "fill-range"
       ]
     },
-    "browserslist@4.25.3": {
-      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+    "browserslist@4.25.4": {
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "dependencies": [
         "caniuse-lite",
         "electron-to-chromium",
@@ -400,6 +526,20 @@
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
+    },
     "caniuse-api@3.0.0": {
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dependencies": [
@@ -409,8 +549,8 @@
         "lodash.uniq"
       ]
     },
-    "caniuse-lite@1.0.30001737": {
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw=="
+    "caniuse-lite@1.0.30001739": {
+      "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA=="
     },
     "chalk@5.6.0": {
       "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ=="
@@ -470,6 +610,13 @@
       "dependencies": [
         "mdn-data@2.12.2",
         "source-map-js"
+      ]
+    },
+    "css-vendor@2.0.8": {
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "dependencies": [
+        "@babel/runtime",
+        "is-in-browser"
       ]
     },
     "css-what@6.2.2": {
@@ -548,6 +695,9 @@
         "css-tree@2.2.1"
       ]
     },
+    "csstype@3.1.3": {
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "cubic-spline@3.0.3": {
       "integrity": "sha512-yAvcHgrpf/k83pZiO4+R2reWOJlufgjpQhmDD3OXa8YMbjmRgjtUK8pcFOCZvJwqXaMD1isZdL7Z4ghqDPN/yw=="
     },
@@ -592,11 +742,22 @@
         "domhandler"
       ]
     },
-    "electron-to-chromium@1.5.209": {
-      "integrity": "sha512-Xoz0uMrim9ZETCQt8UgM5FxQF9+imA7PBpokoGcZloA1uw2LeHzTlip5cb5KOAsXZLjh/moN2vReN3ZjJmjI9A=="
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
     },
-    "emoji-regex@10.4.0": {
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+    "earcut@2.2.4": {
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
+    "electron-to-chromium@1.5.212": {
+      "integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww=="
+    },
+    "emoji-regex@10.5.0": {
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="
     },
     "engine.io-client@6.6.3": {
       "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
@@ -613,6 +774,18 @@
     },
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
     },
     "esbuild@0.25.9": {
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
@@ -650,6 +823,16 @@
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
+    "eventemitter3@4.0.7": {
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "fast-xml-parser@5.2.5": {
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dependencies": [
+        "strnum"
+      ],
+      "bin": true
+    },
     "fill-range@7.1.1": {
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": [
@@ -665,8 +848,48 @@
         "trigram-utils"
       ]
     },
-    "get-east-asian-width@1.3.0": {
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-east-asian-width@1.3.1": {
+      "integrity": "sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hyphenate-style-name@1.1.0": {
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
     },
     "immutable@5.1.3": {
       "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg=="
@@ -680,6 +903,9 @@
         "is-extglob"
       ]
     },
+    "is-in-browser@1.1.3": {
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
+    },
     "is-interactive@2.0.0": {
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
     },
@@ -691,6 +917,129 @@
     },
     "is-unicode-supported@2.1.0": {
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
+    },
+    "ismobilejs@1.1.1": {
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
+    },
+    "jss-plugin-camel-case@10.10.0": {
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+      "dependencies": [
+        "@babel/runtime",
+        "hyphenate-style-name",
+        "jss"
+      ]
+    },
+    "jss-plugin-compose@10.10.0": {
+      "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "tiny-warning"
+      ]
+    },
+    "jss-plugin-default-unit@10.10.0": {
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss"
+      ]
+    },
+    "jss-plugin-expand@10.10.0": {
+      "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss"
+      ]
+    },
+    "jss-plugin-extend@10.10.0": {
+      "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "tiny-warning"
+      ]
+    },
+    "jss-plugin-global@10.10.0": {
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss"
+      ]
+    },
+    "jss-plugin-nested@10.10.0": {
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "tiny-warning"
+      ]
+    },
+    "jss-plugin-props-sort@10.10.0": {
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss"
+      ]
+    },
+    "jss-plugin-rule-value-function@10.10.0": {
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "tiny-warning"
+      ]
+    },
+    "jss-plugin-rule-value-observable@10.10.0": {
+      "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "symbol-observable"
+      ]
+    },
+    "jss-plugin-template@10.10.0": {
+      "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "tiny-warning"
+      ]
+    },
+    "jss-plugin-vendor-prefixer@10.10.0": {
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+      "dependencies": [
+        "@babel/runtime",
+        "css-vendor",
+        "jss"
+      ]
+    },
+    "jss-preset-default@10.10.0": {
+      "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
+      "dependencies": [
+        "@babel/runtime",
+        "jss",
+        "jss-plugin-camel-case",
+        "jss-plugin-compose",
+        "jss-plugin-default-unit",
+        "jss-plugin-expand",
+        "jss-plugin-extend",
+        "jss-plugin-global",
+        "jss-plugin-nested",
+        "jss-plugin-props-sort",
+        "jss-plugin-rule-value-function",
+        "jss-plugin-rule-value-observable",
+        "jss-plugin-template",
+        "jss-plugin-vendor-prefixer"
+      ]
+    },
+    "jss@10.10.0": {
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+      "dependencies": [
+        "@babel/runtime",
+        "csstype",
+        "is-in-browser",
+        "tiny-warning"
+      ]
     },
     "kuroshiro@1.2.0": {
       "integrity": "sha512-yBGCK9oDOY3LGZ/KXaN9m7ADcAuSczOR2FoMRYwHLUlis3/o/uxdMVROAjENFO0NQJgALhIdWxI/vIBVrMCk9w==",
@@ -722,6 +1071,9 @@
         "chalk",
         "is-unicode-supported@1.3.0"
       ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "mdn-data@2.0.28": {
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
@@ -763,6 +1115,9 @@
       "dependencies": [
         "boolbase"
       ]
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
     "onetime@7.0.0": {
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
@@ -1039,6 +1394,15 @@
         "source-map-js"
       ]
     },
+    "punycode@1.4.1": {
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
+    "qs@6.14.0": {
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
     "readdirp@4.1.2": {
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
@@ -1063,6 +1427,42 @@
     },
     "sax@1.4.1": {
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "side-channel-list@1.0.0": {
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
     },
     "signal-exit@4.1.0": {
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
@@ -1126,6 +1526,9 @@
         "ansi-regex"
       ]
     },
+    "strnum@2.1.1": {
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+    },
     "stylehacks@7.0.6_postcss@8.5.6": {
       "integrity": "sha512-iitguKivmsueOmTO0wmxURXBP8uqOO+zikLGZ7Mm9e/94R4w5T999Js2taS/KBOnQ/wdC3jN3vNSrkGDrlnqQg==",
       "dependencies": [
@@ -1147,6 +1550,9 @@
       ],
       "bin": true
     },
+    "symbol-observable@1.2.0": {
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "terser@5.43.1": {
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dependencies": [
@@ -1156,6 +1562,9 @@
         "source-map-support"
       ],
       "bin": true
+    },
+    "tiny-warning@1.0.3": {
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -1170,7 +1579,7 @@
         "n-gram"
       ]
     },
-    "update-browserslist-db@1.1.3_browserslist@4.25.3": {
+    "update-browserslist-db@1.1.3_browserslist@4.25.4": {
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dependencies": [
         "browserslist",
@@ -1178,6 +1587,13 @@
         "picocolors"
       ],
       "bin": true
+    },
+    "url@0.11.4": {
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dependencies": [
+        "punycode",
+        "qs"
+      ]
     },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
@@ -1192,9 +1608,11 @@
   "workspace": {
     "dependencies": [
       "jsr:@socali/modules@^4.4.1",
-      "jsr:@spicetify/bundler@^1.0.7",
+      "jsr:@spicetify/bundler@^1.1.9",
       "jsr:@spikerko/tools@^1.5.6",
-      "jsr:@spikerko/web-modules@^1.0.5"
+      "jsr:@spikerko/web-modules@^1.0.5",
+      "npm:@applemusic-like-lyrics/core@~0.1.3",
+      "npm:fast-xml-parser@^5.2.5"
     ]
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -72,6 +72,14 @@ async function main() {
     Defaults.CompactMode_LockedMediaBox = storage.get("lockedMediaBox") === "true";
   }
 
+  if (!storage.get("lyricsRenderer")) {
+    storage.set("lyricsRenderer", "Spicy")
+  }
+
+  if (storage.get("lyricsRenderer")) {
+    Defaults.LyricsRenderer = storage.get("lyricsRenderer").toString() as string;
+  }
+
  /*  if (!storage.get("lyrics_spacing")) {
     storage.set("lyrics_spacing", "Medium");
   } */
@@ -126,7 +134,7 @@ async function main() {
   }
 
 
-  Defaults.SpicyLyricsVersion = window._spicy_lyrics_metadata?.LoadedVersion ?? "5.10.7";
+  Defaults.SpicyLyricsVersion = window._spicy_lyrics_metadata?.LoadedVersion ?? "5.10.9";
   
 
   /* if (storage.get("lyrics_spacing")) {
@@ -431,7 +439,7 @@ async function main() {
 			if (controlsContainer === null) {
 				Defer(SearchDOMForFullscreenButtons)
 			} else {
-        // @ts-expect-error 123
+        // @ts-ignore 123
 				for (const element of controlsContainer.children) {
 					if (
 						(
@@ -527,7 +535,7 @@ async function main() {
     async function applyDynamicBackgroundToNowPlayingBar(coverUrl: string | undefined) {
       if (Defaults.hide_npv_bg) return;
       if (SpotifyPlayer.GetContentType() === "unknown" || SpotifyPlayer.IsDJ()) return;
-      if (Defaults.StaticBackground || coverUrl === undefined) return;
+      if (Defaults.StaticBackground || Defaults.CanvasBackground || coverUrl === undefined) return;
       const nowPlayingBar =
         document.querySelector<HTMLElement>(".Root__right-sidebar aside.NowPlayingView") ??
         document.querySelector<HTMLElement>(`.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.main-nowPlayingView-coverArtContainer)`);

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -131,7 +131,112 @@ export default async function ApplyDynamicBackground(element: HTMLElement) {
 
     const TrackId = SpotifyPlayer.GetId() ?? undefined;
 
-    if (Defaults.StaticBackground) {
+    // TODO: Finish
+    /* if (Defaults.CanvasBackground && isSpicySidebarMode) { // Canvas Mode
+        try {
+            const response = await Spicetify.GraphQL.Request(
+                Spicetify.GraphQL.Definitions.canvas,
+                {
+                    uri: `spotify:track:${TrackId}`
+                }
+            )
+
+            if (!response.errors) {
+                const canvasObject = response?.data?.trackUnion?.canvas;
+                if (canvasObject && canvasObject != null) {
+                    const canvasUrl = canvasObject?.url;
+                    if (canvasUrl) {
+                        const prevBg = element.querySelector<HTMLElement>(".spicy-dynamic-bg.CanvasBackground");
+
+                        const processVideo = async (img: HTMLImageElement, canvasUrl: string) => {
+                            try {
+                                // Fetch the video file
+                                const response = await fetch(canvasUrl);
+                                if (!response.ok) throw new Error(`Failed to fetch video: ${response.status}`);
+
+                                const arrayBuffer = await response.arrayBuffer();
+                                const videoBlob = new Blob([arrayBuffer], { type: "video/mp4" });
+                                const videoUrl = URL.createObjectURL(videoBlob);
+
+                                // Create temporary video to extract frames
+                                const tempVideo = document.createElement("video");
+                                tempVideo.src = videoUrl;
+                                tempVideo.muted = true;
+                                tempVideo.playsInline = true;
+                                tempVideo.autoplay = false;
+                                tempVideo.crossOrigin = "anonymous";
+
+                                await new Promise<void>(resolve => {
+                                    tempVideo.addEventListener("loadeddata", () => resolve(), { once: true });
+                                });
+
+                                // Prepare GIF
+                                const gif = new GIF({
+                                    workers: 2,
+                                    quality: 10,
+                                    width: tempVideo.videoWidth,
+                                    height: tempVideo.videoHeight
+                                });
+
+                                const canvas = document.createElement("canvas");
+                                canvas.width = tempVideo.videoWidth;
+                                canvas.height = tempVideo.videoHeight;
+                                const ctx = canvas.getContext("2d");
+
+                                // Capture frames every 100ms
+                                const duration = tempVideo.duration;
+                                for (let t = 0; t < duration; t += 0.1) {
+                                    tempVideo.currentTime = t;
+                                    await new Promise(r => tempVideo.addEventListener("seeked", r, { once: true }));
+                                    ctx?.drawImage(tempVideo, 0, 0, canvas.width, canvas.height);
+                                    gif.addFrame(ctx!, { copy: true, delay: 100 });
+                                }
+
+                                // Render GIF to blob
+                                const gifBlob: Blob = await new Promise(resolve => {
+                                    gif.on("finished", (blob: Blob) => resolve(blob));
+                                    gif.render();
+                                });
+
+                                const gifBlobUrl = URL.createObjectURL(gifBlob);
+
+                                // Set the image source to the GIF blob
+                                img.src = gifBlobUrl;
+                            } catch (err) {
+                                console.error("Error in processVideo:", err);
+                            }
+                        };
+
+                        if (prevBg) {
+                            const prevBgImg = prevBg.querySelector<HTMLImageElement>("img");
+                            if (prevBgImg) {
+                                await processVideo(prevBgImg, canvasUrl);
+                            } else {
+                                prevBg.innerHTML = `<img />`;
+                                await processVideo(prevBg.querySelector<HTMLImageElement>("img"), canvasUrl);
+                            }
+                        } else {
+                            const bgContainer = document.createElement("div");
+                            bgContainer.classList.add("spicy-dynamic-bg", "CanvasBackground");
+
+                            bgContainer.innerHTML = `<img />`;
+
+                            await processVideo(bgContainer.querySelector<HTMLImageElement>("img"), canvasUrl);
+
+                            element.appendChild(bgContainer);
+                        }
+
+
+                    }
+                }
+                
+            } else {
+                throw new Error(`Failed to fetch canvas: ${status}`);
+            }
+        } catch (error) {
+            console.error("Error while getting canvas video", error)
+        }
+    } else  */if (Defaults.StaticBackground) {
         if (Defaults.StaticBackgroundType === "Color") {
 
             const colorFetch = await Spicetify.CosmosAsync.get(`https://spclient.wg.spotify.com/color-lyrics/v2/track/${SpotifyPlayer.GetId()}/image/${SpotifyPlayer.GetCover("standard") ?? ""}?format=json&vocalRemoval=false&market=from_token`)

--- a/src/components/Global/Defaults.ts
+++ b/src/components/Global/Defaults.ts
@@ -21,7 +21,10 @@ const Defaults = {
     SimpleLyricsMode: false,
     MinimalLyricsMode: false,
     hide_npv_bg: false,
-    CompactMode_LockedMediaBox: false
+    CompactMode_LockedMediaBox: false,
+    LyricsRenderer: "Spicy",
+    LyricsRenderer_Default: 0,
+    CanvasBackground: false,
 }
 
 export default Defaults;

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -19,6 +19,7 @@ import { DestroyAllLyricsContainers } from "../../utils/Lyrics/Applyer/CreateLyr
 import { CloseSidebarLyrics, isSpicySidebarMode, OpenSidebarLyrics } from "../Utils/SidebarLyrics.ts";
 import Whentil from "@spikerko/tools/Whentil";
 import { Spicetify } from "@spicetify/bundler";
+import { resetLyricsPlayer } from "../../utils/Lyrics/Global/Applyer.ts"
 // import { UpdateSongMoreInfo } from "../Utils/Annotations";
 
 interface TippyInstance {
@@ -59,13 +60,22 @@ export const GetPageRoot = () => (
 
 let PageResizeListener: ResizeObserver | null = null;
 
-async function OpenPage(AppendTo: HTMLElement | undefined = undefined) {
+async function OpenPage(AppendTo: HTMLElement | undefined = undefined, isSidebarMode: boolean = false) {
     if (PageView.IsOpened) return;
     /* if (!HoverMode) {
         PageView.IsTippyCapable = false;
     } */
     const elem = document.createElement("div");
     elem.id = "SpicyLyricsPage";
+
+    if (Defaults.LyricsRenderer === "Spicy") {
+        elem.classList.add("SpicyRenderer")
+    }
+
+    if (isSidebarMode) {
+        elem.classList.add("SidebarMode")
+    }
+
     /* if (HoverMode) {
         elem.classList.add("TippyMode");
     } */
@@ -237,7 +247,10 @@ export function Compactify(Element: HTMLElement | undefined = undefined) {
 function DestroyPage() {
     if (!PageView.IsOpened) return;
     if (Fullscreen.IsOpen) Fullscreen.Close();
-    if (!document.querySelector("#SpicyLyricsPage")) return
+    if (!document.querySelector("#SpicyLyricsPage")) return;
+
+    resetLyricsPlayer();
+
     CleanupDynamicBGLets();
     ResetLastLine();
     CleanupScrollEvents();
@@ -296,7 +309,7 @@ function AppendViewControls(ReAppend: boolean = false) {
     elem.innerHTML = `
         ${(Fullscreen.IsOpen || Fullscreen.CinemaViewOpen) ? "" : `<button id="CinemaView" class="ViewControl">${Icons.CinemaView}</button>`}
         ${(Fullscreen.IsOpen || Fullscreen.CinemaViewOpen) ? `<button id="CompactModeToggle" class="ViewControl">${IsCompactMode() ? Icons.DisableCompactModeIcon : Icons.EnableCompactModeIcon}</button>` : ""}
-        <button id="RomanizationToggle" class="ViewControl">${isRomanized ? Icons.DisableRomanization : Icons.EnableRomanization}</button>
+        ${Defaults.LyricsRenderer === "Spicy" ? `<button id="RomanizationToggle" class="ViewControl">${isRomanized ? Icons.DisableRomanization : Icons.EnableRomanization}</button>` : ""}
         ${(!Fullscreen.IsOpen && !Fullscreen.CinemaViewOpen && !isSpicySidebarMode) ? `<button id="NowBarToggle" class="ViewControl">${Icons.NowBar}</button>` : ""}
         ${NowBarObj.Open && !(isNoLyrics && (Fullscreen.IsOpen || Fullscreen.CinemaViewOpen)) && !isSpicySidebarMode ? `<button id="NowBarSideToggle" class="ViewControl">${Icons.Fullscreen}</button>` : ""}
         ${Fullscreen.IsOpen ? `<button id="FullscreenToggle" class="ViewControl">${Fullscreen.CinemaViewOpen ? Icons.Fullscreen : Icons.CloseFullscreen}</button>` : ""}

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -104,7 +104,7 @@ export function OpenSidebarLyrics(wasOpenForceUndefined: boolean = false) {
             () => getQueueContainer() && !PageView.IsOpened,
             () => {
                 // console.log("[Spicy Lyrics Debug] finalContainer appeared after click");
-                PageView.Open(parentContainer);
+                PageView.Open(parentContainer, true);
                 Whentil.When(() => currentPageBgInstance, () => {
                     SetPageBGBlur(100);
                 })
@@ -119,7 +119,7 @@ export function OpenSidebarLyrics(wasOpenForceUndefined: boolean = false) {
             () => finalContainer && !PageView.IsOpened,
             () => {
                 // console.log("[Spicy Lyrics Debug] Whentil with existing container");
-                PageView.Open(parentContainer);
+                PageView.Open(parentContainer, true);
                 Whentil.When(() => currentPageBgInstance, () => {
                     SetPageBGBlur(100);
                 })

--- a/src/css/ContentBox.css
+++ b/src/css/ContentBox.css
@@ -47,7 +47,34 @@
     --LyricsRightSidePadding: 15.5cqw;
 }
 
-#SpicyLyricsPage:not(.SidebarMode):has(.NowBar.Active) {
+#SpicyLyricsPage:not(.SpicyRenderer) {
+    --LyricsLeftSidePadding: 10cqw;
+    --LyricsRightSidePadding: 8cqw;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer) .LyricsContainer .LyricsContent {
+    padding-left: var(--LyricsLeftSidePadding) !important;
+    padding-right: var(--LyricsRightSidePadding) !important;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer).SidebarMode .LyricsContainer .LyricsContent {
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer):not(.SidebarMode):has(.NowBar.Active) .LyricsContainer .LyricsContent,
+#SpicyLyricsPage:not(.SpicyRenderer):not(.Fullscreen):not(.SidebarMode):has(.NowBar.Active) .LyricsContainer .LyricsContent {
+    padding-left: calc(var(--LyricsLeftSidePadding) - 2.5cqw) !important;
+    padding-right: calc(var(--LyricsRightSidePadding) - 4cqw) !important;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer) .ContentBox .NowBar.Active:is(.RightSide) + .LyricsContainer .LyricsContent {
+    padding-right: calc(var(--LyricsLeftSidePadding) - 4cqw) !important;
+    padding-left: calc(var(--LyricsRightSidePadding) * 1.45 - 2.5cqw) !important;
+}
+
+
+#SpicyLyricsPage:not(.SidebarMode):not(.CompactMode):has(.NowBar.Active) {
     --LyricsLeftSidePadding: calc(50cqw - var(--NowBarRightSpacing)* 0.3);
     --LyricsRightSidePadding: calc(var(--NowBarLeftSpacing)* 0.35);
 }
@@ -56,6 +83,11 @@
     --NowBarLeftSpacing: calc(calc(50cqw - var(--NowBarWidth) - var(--NowBarRightSpacing)) * .7);
     --LyricsLeftSidePadding: calc(calc(50cqw - var(--NowBarRightSpacing)* 0.3) * .9);
 }
+/* 
+#SpicyLyricsPage:not(.SpicyRenderer).Fullscreen.CompactMode {
+    --LyricsLeftSidePadding: 11cqw;
+    --LyricsRightSidePadding: 9cqw;
+} */
 
 #SpicyLyricsPage .ContentBox .NowBar {
     --title-height: 4.2cqh;
@@ -769,7 +801,7 @@
     padding-top: 5cqh !important;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode {
+#SpicyLyricsPage:not(.SpicyRenderer).Fullscreen.CompactMode {
     --LyricsLeftSidePadding: 18cqw !important;
     --LyricsRightSidePadding: 15.5cqw !important;
 }
@@ -803,7 +835,7 @@
     --DefaultLyricsSize: clamp(2.5rem, calc(1cqw* 7), 3.5rem);
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode:has(.MediaBox:hover) .ContentBox .LyricsContainer {
+#SpicyLyricsPage.Fullscreen.CompactMode.SpicyRenderer:has(.MediaBox:hover) .ContentBox .LyricsContainer {
     margin-top: calc(var(--Compact_NowBarHeight) + 50cqw);
 }
 
@@ -816,33 +848,33 @@
     padding: 0 0 10cqh !important;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned) .line.OppositeAligned:not(.rtl),
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned) .line.OppositeAligned:not(.rtl),
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
   padding-left: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl),
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl),
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
   padding-right: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned.rtl) .line.OppositeAligned,
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned.rtl) .line.OppositeAligned,
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
   padding-right: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned.rtl) .line:not(.OppositeAligned),
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:has(.OppositeAligned.rtl) .line:not(.OppositeAligned),
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
   padding-left: 10cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:not(:has(.OppositeAligned)) .line,
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:not(:has(.OppositeAligned)) .line,
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
   padding-right: 2cqw;
 }
 
-#SpicyLyricsPage.Fullscreen.CompactMode .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:not(:has(.OppositeAligned)) .line.rtl,
-#SpicyLyricsPage.TippyMode .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
+#SpicyLyricsPage.Fullscreen.CompactMode.LyricsRenderer .LyricsContainer .LyricsContent.CompactifyEnabledCompactMode:not(:has(.OppositeAligned)) .line.rtl,
+#SpicyLyricsPage.TippyMode.LyricsRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
   padding-left: 2cqw;
 }
 
@@ -876,7 +908,7 @@
     scale: 1.05;
 }
 
-#SpicyLyricsPage:not(.CompactifyEnabledCompactMode).Fullscreen.CompactMode:has(.MediaBox:hover) .ContentBox .LyricsContainer,
+#SpicyLyricsPage.SpicyRenderer:not(.CompactifyEnabledCompactMode).Fullscreen.CompactMode:has(.MediaBox:hover) .ContentBox .LyricsContainer,
 #SpicyLyricsPage:not(.CompactifyEnabledCompactMode).Fullscreen.CompactMode:has(.NowBar.LockedMediaBox) .ContentBox .LyricsContainer {
     margin-top: calc(var(--Compact_NowBarHeight) + 18cqw);
 }
@@ -889,4 +921,25 @@
 #SpicyLyricsPage.Fullscreen.CompactMode .ContentBox .NowBar .Header .MediaBox .MediaImage {
     border-radius: 3cqh;
     --BorderRadius: 3cqh;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer) .LyricsContainer .LyricsContent > div > div {
+    transition: filter 0.25s, background-color 0.25s, box-shadow 0.25s, transform 0.37s !important;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer) .LyricsContainer .LyricsContent > div {
+    --bottom-push: 0px;
+    position: relative;
+    bottom: var(--bottom-push);
+    --height-value: calc(100% + var(--bottom-push));
+    height: var(--height-value) !important;
+    max-height: var(--height-value) !important;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer).CompactMode .LyricsContainer .LyricsContent > div {
+    --bottom-push: 62cqh;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer).CompactMode.CompactifyEnabledCompactMode .LyricsContainer .LyricsContent > div {
+    padding: 0.2em 0.5em 1em 0.5em !important;
 }

--- a/src/css/DynamicBG/spicy-dynamic-bg.css
+++ b/src/css/DynamicBG/spicy-dynamic-bg.css
@@ -37,10 +37,15 @@ aside .spicy-dynamic-bg {
 }
 
 /* Video element styling */
-aside:has(.spicy-dynamic-bg) video {
-  filter: opacity(0.8) brightness(.85);
+aside video {
+  filter: brightness(.6);
   -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
+  transition: filter .25s linear;
+}
+
+aside video:hover {
+  filter: brightness(.95);
 }
 
 /* Reset styles for videos inside VideoPlayer__container */
@@ -50,8 +55,8 @@ aside:has(.spicy-dynamic-bg) video {
   mask-image: none !important;
 }
 
-.main-nowPlayingView-coverArtContainer div:has(video)::before,
-.main-nowPlayingView-coverArtContainer div:has(video)::after {
+.main-nowPlayingView-coverArtContainer :is(div, .E08D6ucrHuPJYzzGO7HG):has(video)::before,
+.main-nowPlayingView-coverArtContainer :is(div, .E08D6ucrHuPJYzzGO7HG):has(video)::after {
   display: none;
 }
 
@@ -125,4 +130,14 @@ body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar aside:is(.NowPlayingV
   height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
   z-index: 2;
+}
+
+#SpicyLyricsPage .spicy-dynamic-bg.CanvasBackground {
+  width: 100%;
+  height: 100%;
+}
+
+#SpicyLyricsPage .spicy-dynamic-bg.CanvasBackground video {
+  width: 100%;
+  height: 100%;
 }

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -3,19 +3,19 @@
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup,
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line .dotGroup, */
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .dot {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup,
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .dotGroup, */
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .dot {
   will-change: transform, opacity, text-shadow, scale, background-image;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent.HideLineBlur .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent.HideLineBlur .line {
     --BlurAmount: 0px !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line {
   --font-size: var(--DefaultLyricsSize);
   display: flex;
   flex-wrap: wrap;
@@ -23,9 +23,9 @@
   font-size: var(--font-size);
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line {
   cursor: pointer;
   font-weight: 700;
   -webkit-text-fill-color: transparent;
@@ -34,9 +34,9 @@
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter {
   --gradient-position: -20%;
   --gradient-color: 255;
   --gradient-alpha: 0.85;
@@ -51,24 +51,24 @@
   initial-value: -50%;
 }
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letter {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letter {
   --gradient-alpha: 1;
   --gradient-alpha-end: 0.3;
 }
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word:not(.dot),
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letter {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word:not(.dot),
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letter {
   --SLM_GradientPosition: -50%;
   --gradient-position: var(--SLM_GradientPosition, -50%) !important;
   --gradient-offset: 30% !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.static {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.static {
   background-image:
       linear-gradient(var(--gradient-degrees),
         rgba(255,255,255,var(--gradient-alpha))
@@ -76,25 +76,25 @@
         rgba(255,255,255,var(--gradient-alpha-end)) calc(var(--gradient-position) + 20% + var(--gradient-offset))
       ) ;
 }
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letter {
   text-shadow: 0 0 var(--BlurAmount,0) rgba(var(--gradient-color),var(--gradient-color),var(--gradient-color),var(--gradient-alpha-end));
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .letter,
-#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
   text-shadow: 0 0 var(--BlurAmount,0) rgba(var(--gradient-color),var(--gradient-color),var(--gradient-color),var(--gradient-alpha));
 }
 
-/* #SpicyLyricsPage.Podcast .LyricsContainer .LyricsContent .line,
-#SpicyLyricsPage.Podcast .LyricsContainer .LyricsContent .line .word {
+/* #SpicyLyricsPage.SpicyRenderer.Podcast .LyricsContainer .LyricsContent .line,
+#SpicyLyricsPage.SpicyRenderer.Podcast .LyricsContainer .LyricsContent .line .word {
   background-image: linear-gradient(var(--gradient-degrees), rgba(255, 255, 255, var(--gradient-alpha)) var(--gradient-position), rgba(0, 0, 0, var(--gradient-alpha-end)) calc(var(--gradient-position) + 20% + var(--gradient-offset))) !important;
 } */
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line {
   --BlurAmount: 0px;
   
   --DefaultLyricsScale: 0.95;
@@ -115,143 +115,143 @@
   direction: ltr;
 }
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line {
   --Vocal-NotSung-opacity: 0.45;
   --Vocal-Sung-opacity: 0.35;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.rtl {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.rtl {
   direction: rtl !important;
   transform-origin: right center !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup {
   transform-origin: center center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word.PartOfWord,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word.PartOfWord,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord {
   transform-origin: right center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word.PartOfWord + :is(.word.PartOfWord, .letterGroup.PartOfWord),
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord + :is(.word.PartOfWord, .letterGroup.PartOfWord) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word.PartOfWord + :is(.word.PartOfWord, .letterGroup.PartOfWord),
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord + :is(.word.PartOfWord, .letterGroup.PartOfWord) {
   transform-origin: center center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word.PartOfWord + :is(.word, .letterGroup),
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord + :is(.word, .letterGroup) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word.PartOfWord + :is(.word, .letterGroup),
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup.PartOfWord + :is(.word, .letterGroup) {
   transform-origin: left center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word, 
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line .dotGroup,  */
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word, 
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .dotGroup,  */
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup {
   --text-shadow-blur-radius: 4px;
   --text-shadow-opacity: 0%;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.musical-line) .word, 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.musical-line) .word, 
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup {
   display: inline-block;
 }
 
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letterGroup {
   text-shadow: 0 0 var(--text-shadow-blur-radius) rgba(255,255,255,var(--text-shadow-opacity));
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter {
   --gradient-alpha: 0.6;
   --gradient-alpha-end: 0.3;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.OppositeAligned {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.OppositeAligned {
   justify-content: flex-end;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung {
   opacity: var(--Vocal-Sung-opacity);
   --gradient-position: 100% !important;
 }
 
-/* #SpicyLyricsPage.Podcast .LyricsContainer .LyricsContent .line.Sung {
+/* #SpicyLyricsPage.SpicyRenderer.Podcast .LyricsContainer .LyricsContent .line.Sung {
   opacity: .3 !important;
 }
  */
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung {
   scale: var(--DefaultLineScale);
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung {
   opacity: var(--Vocal-NotSung-opacity);
   --gradient-position: -20% !important;
 }
 
-/* #SpicyLyricsPage.Podcast .LyricsContainer .LyricsContent .line.NotSung {
+/* #SpicyLyricsPage.SpicyRenderer.Podcast .LyricsContainer .LyricsContent .line.NotSung {
   opacity: .34 !important;
 }
  */
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung:hover,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung:hover .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung:hover .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung:hover,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung:hover .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung:hover .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung:hover,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung:hover .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung:hover .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung:hover,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung:hover .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung:hover .letter {
   opacity: var(--Vocal-Hover-opacity, 1) !important;
   --BlurAmount: 0px !important;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word:not(.PartOfWord, .dot, .LastWordInLine)::after,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup:not(.PartOfWord, .dot, .LastWordInLine)::after {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word:not(.PartOfWord, .dot, .LastWordInLine)::after,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup:not(.PartOfWord, .dot, .LastWordInLine)::after {
   content: "";
   margin-right: .3ch;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letter {
   --text-shadow-blur-radius: 4px !important;
   --text-shadow-opacity: 0% !important;
   --gradient-position: -20% !important;
 }
 
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .word {
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .word {
   transform: translateY(calc(var(--DefaultLyricsSize) * 0.01)) !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letterGroup,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letterGroup,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letter {
   transform: translateY(calc(var(--DefaultLyricsSize) * 0.02)) !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung .letterGroup {
   scale: var(--DefaultEmphasisLyricsScale);
 } */
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .word-group {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .word-group {
   display: inline-flex;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung .letter {
   --gradient-position: 100% !important;
 /*   --text-shadow-blur-radius: 4px !important;
   --text-shadow-opacity: 0% !important;
@@ -259,35 +259,35 @@
   scale: 1 !important; */
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.FeelSung .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.FeelSung .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.FeelSung .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.FeelSung .letter {
   --text-shadow-blur-radius: 4px !important;
   --text-shadow-opacity: 0% !important;
   transform: translateY(0) !important;
   scale: 1 !important;
 }
 
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung .letterGroup {
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung .letterGroup {
   transform: translateY(0) !important;
 } */
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line .letterGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup {
   display: inline-flex ;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line .letterGroup,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line .letterGroup,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter {
   --font-size: calc(var(--DefaultLyricsSize)*0.75);
   font-size: var(--font-size);
   font-weight: 600;
 }
 
-#SpicyLyricsPage.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line,
-#SpicyLyricsPage.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .word,
-#SpicyLyricsPage.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .letterGroup,
-#SpicyLyricsPage.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter  {
+#SpicyLyricsPage.SpicyRenderer.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line,
+#SpicyLyricsPage.SpicyRenderer.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .word,
+#SpicyLyricsPage.SpicyRenderer.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .letterGroup,
+#SpicyLyricsPage.SpicyRenderer.UseSpicyFont .LyricsContainer .LyricsContent .line.bg-line .letterGroup .letter  {
   font-family: SpicyLyrics;
 }
 
@@ -309,12 +309,12 @@
   }
 } */
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.bg-line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.bg-line {
   margin: -1cqw 0 1cqw !important;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
   --dot-gap: clamp(0.005rem, 1.7cqw, 0.18rem);
   display: flex;
   flex-direction: row;
@@ -322,11 +322,11 @@
   /* animation: MusicalLineScaleLoop 5s cubic-bezier(.35,.29,.51,1.11) infinite; */
 }
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
   --dot-gap: clamp(0.0067rem, 1.76cqw, 0.32rem);
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line .dotGroup .dot {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line .dotGroup .dot {
   --font-size: calc(var(--DefaultLyricsSize)*1.3);
   --opacity-size: .35;
   border-radius: 50%;
@@ -336,48 +336,48 @@
   --gradient-position: 100%;
 }
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line.musical-line .dotGroup .dot {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line.musical-line .dotGroup .dot {
   --opacity-size: .27;
   scale: 1;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active {
   opacity: 1;
   --BlurAmount: 0px !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letterGroup,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.Active .letterGroup .letter {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letterGroup,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letterGroup .letter {
   opacity: 1;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.static {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.static {
   cursor: default;
   --gradient-position: 100%;
   --gradient-alpha: 1;
   --gradient-alpha-end: 1;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent.offline {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent.offline {
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.musical-line) {
   margin: var(--SpicyLyrics-LineSpacing, 1cqw 0);
 /*   margin-left: 18cqw;
   margin-right: 30cqw; */
 }
 
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line.OppositeAligned {
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.OppositeAligned {
   margin-right: 16cqw;
   margin-left: 30cqw;
 } */
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .Credits {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .Credits {
   --font-size: calc(var(--DefaultLyricsSize)*0.47);
   font-weight: 600;
   font-size: var(--font-size);
@@ -387,7 +387,7 @@
   transition: color 0.5s ease-in-out !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SongInfo {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SongInfo {
   --font-size: calc(var(--DefaultLyricsSize)* 0.35);
   font-size: var(--font-size);
   font-weight: 600;
@@ -402,13 +402,13 @@
   transition: opacity .5s, scale .25s;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:has(.Credits.Active) .SongInfo {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.Credits.Active) .SongInfo {
   opacity: 1;
   scale: 1.02;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SongInfo .Uploader,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SongInfo .Maker {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SongInfo .Uploader,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SongInfo .Maker {
   --font-size: calc(var(--DefaultLyricsSize)* 0.33);
   font-size: var(--font-size);
   display: flex;
@@ -417,18 +417,18 @@
   gap: .65cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SongInfo .Uploader img,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SongInfo .Maker img {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SongInfo .Uploader img,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SongInfo .Maker img {
   width: 24px;
   height: 24px;
   border-radius: 50%;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .Credits.Active {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .Credits.Active {
   color: white;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line {
   --text-shadow-blur-radius: 4px;
   --text-shadow-opacity: 0%;
   transform-origin: left center;
@@ -437,62 +437,62 @@
 /*   text-shadow: 0 0 var(--text-shadow-blur-radius) rgba(255,255,255,var(--text-shadow-opacity)); */
 }
 
-#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line:not(.Active) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line:not(.Active) {
   --text-shadow-blur-radius: 4px !important;
   --text-shadow-opacity: 0% !important;
 }
 
-#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.OppositeAligned {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.OppositeAligned {
   transform-origin: right center;
 }
 
-body:not(.SpicySidebarLyrics__Active) #SpicyLyricsPage:not(.Fullscreen.MinimalLyricsMode) .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
+body:not(.SpicySidebarLyrics__Active) #SpicyLyricsPage.SpicyRenderer:not(.Fullscreen.MinimalLyricsMode) .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
   scale: 1.05;
   /* text-shadow: var(--ActiveTextGlowDef) !important; */
 }
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line.Active:not(.musical-line) {
   scale: 1;
 }
 
-#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] {
   --DefaultLyricsSize: clamp(0.8rem,calc(1cqw* 5), 2.5rem);
 }
 
-#SpicyLyricsPage .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
   font-weight: 500;
 }
 
-/* #SpicyLyricsPage.Podcast .LyricsContainer .LyricsContent .line.Sung .word {
+/* #SpicyLyricsPage.SpicyRenderer.Podcast .LyricsContainer .LyricsContent .line.Sung .word {
   scale: 1 !important;
   transform: translateY(calc(var(--DefaultLyricsSize) * 0)) !important;
 } */
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
   padding-left: 25cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
   padding-right: 25cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
   padding-right: 25cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
   padding-left: 25cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
   padding-right: 5cqw;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
   padding-left: 5cqw;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line {
   transition: line-height 0.14s, margin 0.1s, z-index 0.1s !important;
   position: relative;
   transform-origin: center center !important;
@@ -503,108 +503,108 @@ body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .SpicyLyricsSc
   /* scale: 0 !important; */
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line .dotGroup {
   transition: scale 0.25s !important;
   scale: 0;
   font-family: SpicyLyrics !important;
   transform-origin: center center;
 }
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line.Active {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line.Active {
   z-index: -1;
   margin: -1.3cqw 0 !important;
   line-height: var(--lyrics-line-height) !important;
 }
 
 
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line.musical-line.Active .dotGroup {
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.musical-line.Active .dotGroup {
   scale: 1 !important;
 }
 
-/* #SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letterGroup,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letterGroup .letter,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .dotGroup,
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .line .dotGroup .dot {
+/* #SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .word,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letterGroup,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .letterGroup .letter,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .dotGroup,
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .line .dotGroup .dot {
   --BlurAmount: 0px !important;
 } */
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line:not(.musical-line) {
   transform-origin: left center;
   transition: scale .4s ease-in-out, opacity .4s linear !important;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.OppositeAligned:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.OppositeAligned:not(.musical-line) {
   transform-origin: right center;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.rtl:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.rtl:not(.musical-line) {
   transform-origin: right center;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.rtl.OppositeAligned:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.rtl.OppositeAligned:not(.musical-line) {
   transform-origin: left center;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.Active:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent .line.Active:not(.musical-line) {
   scale: 1;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Sung:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Sung:not(.musical-line) {
   scale: 0.95;
   opacity: 0;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotSung:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotSung:not(.musical-line) {
   scale: 0.965;
   opacity: 0.35;
 }
 
-/* #SpicyLyricsPage.Fullscreen.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotInViewport {
+/* #SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotInViewport {
   display: none !important;
 } */
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(:has(.line.Active)):not(:has(.line.NotSung)) .line:not(.musical-line):not(.static) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(:has(.line.Active)):not(:has(.line.NotSung)) .line:not(.musical-line):not(.static) {
   scale: 1;
   opacity: var(--Vocal-Sung-opacity, 0.5);
 }
 
-/* #SpicyLyricsPage.Fullscreen.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Sung:has(+ .line.Active) {
+/* #SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Sung:has(+ .line.Active) {
   opacity: 0.2;
 } */
 
 
-/* #SpicyLyricsPage.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotSung {
+/* #SpicyLyricsPage.SpicyRenderer.MinimalLyricsMode .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.NotSung {
   scale: var(--scale-amount, 1);
   margin-bottom: calc(var(--scale-amount)* 7.5px) !important;
   margin: 0;
 } */
 
-#SpicyLyricsPage.SimpleLyricsMode .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line {
+#SpicyLyricsPage.SpicyRenderer.SimpleLyricsMode .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer[data-lyrics-type="Line"] .line {
   --gradient-position: 100% !important;
 }
 
-#SpicyLyricsPage.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Active + .line.Sung:not(.musical-line) {
+#SpicyLyricsPage.SpicyRenderer.Fullscreen.MinimalLyricsMode:not(.CompactMode) .LyricsContainer .LyricsContent:not(.HideLineBlur) .line.Active + .line.Sung:not(.musical-line) {
   opacity: 0.45 !important;
 }
 
 
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.musical-line) {
   transform-origin: left center !important;
   transition: scale .4s ease-in-out, opacity .4s linear !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line.OppositeAligned:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.OppositeAligned:not(.musical-line) {
   transform-origin: right center !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line.rtl:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.rtl:not(.musical-line) {
   transform-origin: right center !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line.rtl.OppositeAligned:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.rtl.OppositeAligned:not(.musical-line) {
   transform-origin: left center !important;
 }
 
@@ -612,43 +612,43 @@ body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent
   --SpicyLyrics-LineSpacing: 1cqw 0 !important;
 } */
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line.NotSung:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.NotSung:not(.musical-line) {
   scale: 0.95 !important;
   opacity: 0.75 !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent .line.Sung:not(.musical-line) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Sung:not(.musical-line) {
   scale: 0.95 !important;
   opacity: 0.34 !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line.OppositeAligned:not(.rtl) {
   padding-left: 10cqw !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned) .line:not(.OppositeAligned, .rtl) {
   padding-right: 10cqw !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line.OppositeAligned {
   padding-right: 10cqw !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:has(.OppositeAligned.rtl) .line:not(.OppositeAligned) {
   padding-left: 10cqw !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line {
   padding-right: 2cqw !important;
 }
 
-body.SpicySidebarLyrics__Active #SpicyLyricsPage .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent:not(:has(.OppositeAligned)) .line.rtl {
   padding-left: 2cqw !important;
 }
 
 
-/* #SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .word,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .letter,
-#SpicyLyricsPage .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .letterGroup {
+/* #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .word,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .letter,
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.Active):not(.musical-line) .letterGroup {
   transition: text-shadow .2s linear !important;
 } */

--- a/src/css/Lyrics/main.css
+++ b/src/css/Lyrics/main.css
@@ -20,6 +20,7 @@
   --StrongTextGlowDef: rgba(255,255,255,0.68) 0px 0px 16.4px;
   --StrongerTextGlowDef: rgba(255,255,255,0.74) 0px 0px 16px;
   --DefaultLyricsSize: clamp(1.85rem,calc(1cqw* 7), 3.5rem);
+  --amll-lyric-player-font-size: var(--DefaultLyricsSize);
   --Simplebar-Scrollbar-Color: rgba(255, 255, 255, 0.6);
   --vertical-gap: 0px;
 

--- a/src/css/default.css
+++ b/src/css/default.css
@@ -364,7 +364,8 @@ body.SpicySidebarLyrics__Active #SpicyLyricsPage {
 }
 
 
-#SpicyLyricsPage:not(.Lyrics_RomanizationAvailable) .ViewControls #RomanizationToggle {
+#SpicyLyricsPage:not(.Lyrics_RomanizationAvailable) .ViewControls #RomanizationToggle,
+#SpicyLyricsPage:not(.SpicyRenderer) .ViewControls #RomanizationToggle {
   display: none !important;
 }
 

--- a/src/edited_packages/applemusic-like-lyrics-lyric/parser.ts
+++ b/src/edited_packages/applemusic-like-lyrics-lyric/parser.ts
@@ -1,0 +1,411 @@
+import { XMLParser } from 'fast-xml-parser';
+
+export interface LyricWord {
+  startTime: number;
+  endTime: number;
+  word: string;
+  romanWord: string;
+}
+
+export interface LyricLine {
+  startTime: number;
+  endTime: number;
+  words: LyricWord[];
+  isDuet: boolean;
+  isBG: boolean; // Background vocal
+  translatedLyric: string;
+  romanLyric: string;
+}
+
+export interface TTMLLyric {
+  lines: LyricLine[];
+  metadata: Map<string, string[]>;
+}
+
+const ADD_INTERLUDE_MS_SPACE = 5000;
+const INTERLUDE_CHARACTER = '♪';
+
+/**
+ * Parses TTML timestamp strings (e.g., "00:01:10.254", "10.24s") into milliseconds.
+ * @param timeStr The timestamp string from the TTML file.
+ * @returns Total time in milliseconds, or null if parsing fails.
+ */
+function parseTimestamp(timeStr: string): number | null {
+  if (!timeStr) return null;
+  const timeRegex =
+    /^(?:(\d{2,3}):)?(\d{1,2}):(\d{1,2})(?:[.](\d+))?|(\d+(?:\.\d+)?)(s?)$/;
+  const match = timeStr.match(timeRegex);
+
+  if (!match) return null;
+
+  // Full HH:MM:SS.ms or MM:SS.ms format
+  if (match[1] !== undefined || match[2] !== undefined) {
+    const hours = match[1] ? parseInt(match[1], 10) : 0;
+    const minutes = parseInt(match[2], 10);
+    const seconds = parseInt(match[3], 10);
+    const fractionStr = match[4] || '0';
+    const milliseconds = parseFloat(`0.${fractionStr}`) * 1000;
+    return (hours * 3600 + minutes * 60 + seconds) * 1000 + milliseconds;
+  }
+
+  // Seconds format (e.g., 10.24s or 10.24)
+  if (match[5] !== undefined) {
+    return parseFloat(match[5]) * 1000;
+  }
+
+  return null;
+}
+
+/**
+ * Parses a TTML string into a structured TTMLLyric object.
+ * @param ttmlString The raw TTML content as a string.
+ * @returns A Promise that resolves with the parsed TTMLLyric object.
+ */
+export function parseTTML(ttmlString: string): Promise<TTMLLyric> {
+  return new Promise((resolve, reject) => {
+    const result: TTMLLyric = {
+      lines: [],
+      metadata: new Map(),
+    };
+
+    const options = {
+      ignoreAttributes: false,
+      attributeNamePrefix: '',
+      textNodeName: '#text',
+      // Ensure these tags are always arrays for consistent processing
+      isArray: (name: string) =>
+        [
+          'p',
+          'span',
+          'ttm:agent',
+          'amll:meta',
+          'text',
+          'div',
+        ].includes(name),
+      trimValues: false,
+    };
+
+    try {
+      const parser = new XMLParser(options);
+      const jsonObj = parser.parse(ttmlString);
+
+      if (!jsonObj.tt) {
+        throw new Error('Invalid TTML structure: missing <tt> root element.');
+      }
+      const tt = jsonObj.tt;
+
+      // --- iTunes Metadata Specific Variables ---
+      const itunesTranslations = new Map<string, string>();
+      const itunesTransliterations = new Map<string, string>();
+      const itunesTransliterationPieces = new Map<string, string[]>();
+      const lineKeyMap: { index: number; key: string }[] = [];
+
+      // --- 1. Parse Metadata ---
+      // Find main agent
+      const Agents = tt.head.metadata['ttm:agent'];
+      const PostAgents =
+        Agents != null ? (Array.isArray(Agents) ? Agents : [Agents]) : [];
+
+      // Determine if an agent represents an opposite alignment based on its ID
+      const isOppositeAlignedAgent = (agent: any) => {
+        const agentId = agent['xml:id'];
+        // v1 is always the main vocal track
+        if (agentId === 'v1') return false;
+        // v2000 and v2 are typically opposite aligned
+        if (agentId === 'v2000' || agentId === 'v2') return true;
+        return false;
+      };
+
+      const TrackAgents =
+        PostAgents.length > 0
+          ? PostAgents.map((agent) => {
+              return {
+                Type: agent.type,
+                Id: agent['xml:id'],
+                OppositeAligned: isOppositeAlignedAgent(agent),
+              };
+            })
+          : [];
+
+      if (tt.head?.metadata) {
+        // Find amll:meta
+        const amllMetas = tt.head.metadata['amll:meta'] || [];
+        for (const meta of amllMetas) {
+          if (meta.key && meta.value) {
+            if (!result.metadata.has(meta.key)) {
+              result.metadata.set(meta.key, []);
+            }
+            result.metadata.get(meta.key)!.push(meta.value);
+          }
+        }
+
+        // Find iTunes metadata
+        const itunesMeta = tt.head.metadata.itunesmetadata;
+        if (itunesMeta) {
+          const translations = itunesMeta.translations?.text || [];
+          for (const trans of translations) {
+            if (trans.for && trans['#text']) {
+              itunesTranslations.set(trans.for, trans['#text']);
+            }
+          }
+          const transliterations = itunesMeta.transliterations?.text || [];
+          for (const trans of transliterations) {
+            if (trans.for) {
+              const fullText = Array.isArray(trans['#text'])
+                ? trans['#text'].join('')
+                : trans['#text'] || '';
+              itunesTransliterations.set(trans.for, fullText);
+
+              const pieces = (trans.span || []).map(
+                (s: any) => s['#text'] || '',
+              );
+              itunesTransliterationPieces.set(trans.for, pieces);
+            }
+          }
+        }
+      }
+
+      const IsPartOfWord = (spans: any[], index: number) => {
+        if (!spans || spans.length <= 0) return false;
+        const nextSpan = spans[index + 1];
+        const span = spans[index];
+        let isPartOfWord = false;
+        if (nextSpan) {
+          // Condition 1: Check tag adjacency
+          let tagsAreAdjacent = false;
+          const endMarker = `end="${span.end}"`;
+          const endMarkerIndex = ttmlString.indexOf(endMarker);
+          if (endMarkerIndex !== -1) {
+            const closingTagIndex = ttmlString.indexOf(
+              '</span>',
+              endMarkerIndex,
+            );
+            if (closingTagIndex !== -1) {
+              const positionAfterCloseTag = closingTagIndex + '</span>'.length;
+              if (
+                ttmlString.length > positionAfterCloseTag &&
+                ttmlString.charAt(positionAfterCloseTag) === '<'
+              ) {
+                tagsAreAdjacent = true;
+              }
+            }
+          }
+
+          // Condition 2: Check if the NEXT span's text starts with whitespace
+          let nextTextStartsWithSpace = false;
+          if (nextSpan['#text'] !== undefined) {
+            const nextText = nextSpan['#text']?.toString() || '';
+            if (/^\s/.test(nextText)) {
+              nextTextStartsWithSpace = true;
+            }
+          }
+
+          // Condition 3: Check if the CURRENT span's text ends with a comma
+          let currentTextEndsWithComma = false;
+          if (span['#text'] !== undefined) {
+            currentTextEndsWithComma = span['#text']
+              ?.toString()
+              ?.trim()
+              .endsWith(',');
+          }
+
+          // Condition 4: Check if the CURRENT span's text ends with whitespace
+          const currentTextEndsWithWhitespace = /\s$/.test(
+            span['#text']?.toString() ?? '',
+          );
+
+          // Combine: True only if tags are adjacent AND next text doesn't start with space AND current text doesn't end with comma AND current text doesn't end with whitespace
+          if (
+            tagsAreAdjacent &&
+            !nextTextStartsWithSpace &&
+            !currentTextEndsWithComma &&
+            !currentTextEndsWithWhitespace
+          ) {
+            isPartOfWord = true;
+          }
+        }
+        return isPartOfWord;
+      };
+
+      // --- 2. Parse Body Content ---
+      const divs = tt.body?.div || [];
+      for (const div of divs) {
+        const paragraphs = div.p || [];
+        for (const p of paragraphs) {
+          const pContent = Array.isArray(p['#text'])
+            ? p['#text'].concat(p.span || [])
+            : [p['#text'], ...(p.span || [])].filter(Boolean);
+
+          // Determine the agent ID for the current p element, falling back to div and then body
+          const pAgentId =
+            p['ttm:agent'] || div['ttm:agent'] || tt.body['ttm:agent'];
+          // Find the corresponding agent in TrackAgents
+          const trackAgent = TrackAgents.find((a) => a.Id === pAgentId);
+          // Determine the OppositeAligned status
+          const isOpposite = trackAgent ? trackAgent.OppositeAligned : false;
+
+          const mainLine: LyricLine = {
+            startTime: parseTimestamp(p.begin) ?? 0,
+            endTime: parseTimestamp(p.end) ?? 0,
+            words: [],
+            isDuet: isOpposite,
+            isBG: false,
+            translatedLyric: '',
+            romanLyric: '',
+          };
+
+          const itunesKey = p['itunes:key'];
+          if (itunesKey) {
+            lineKeyMap.push({ index: result.lines.length, key: itunesKey });
+            mainLine.translatedLyric = itunesTranslations.get(itunesKey) || '';
+            mainLine.romanLyric = itunesTransliterations.get(itunesKey) || '';
+          }
+          result.lines.push(mainLine);
+
+          for (let i = 0; i < pContent.length; i++) {
+            const item = pContent[i];
+            if (typeof item === 'string') {
+              // Text directly in <p> is a word without timing
+              mainLine.words.push({
+                word: item,
+                startTime: 0,
+                endTime: 0,
+                romanWord: '',
+              });
+            } else if (typeof item === 'object' && item !== null) {
+              // This is a <span> element
+              const role = item['ttm:role'];
+              const text = item['#text'] || '';
+
+              if (role === 'x-translation') {
+                if (mainLine.translatedLyric === '')
+                  mainLine.translatedLyric = text;
+              } else if (role === 'x-roman') {
+                if (mainLine.romanLyric === '') mainLine.romanLyric = text;
+              } else if (role === 'x-bg') {
+                // --- MODIFIED SECTION START ---
+                // Background line words are now appended to the current line
+                const bgWords: LyricWord[] = [];
+                const bgContent = Array.isArray(item['#text'])
+                  ? item['#text'].concat(item.span || [])
+                  : [item['#text'], ...(item.span || [])].filter(Boolean);
+
+                for (let bgIndex = 0; bgIndex < bgContent.length; bgIndex++) {
+                  const bgItem = bgContent[bgIndex];
+                  if (typeof bgItem === 'object' && bgItem !== null) {
+                    const bgRole = bgItem['ttm:role'];
+                    // We only care about actual words inside the bg span
+                    if (bgRole !== 'x-translation' && bgRole !== 'x-roman') {
+                      const bgText = bgItem['#text'] || '';
+                      bgWords.push({
+                        startTime: parseTimestamp(bgItem.begin) ?? 0,
+                        endTime: parseTimestamp(bgItem.end) ?? 0,
+                        word: IsPartOfWord(bgContent, bgIndex)
+                          ? `${bgText}`
+                          : `${bgText} `,
+                        romanWord: '',
+                      });
+                    }
+                  }
+                }
+
+                if (bgWords.length > 0) {
+                  // Add opening parenthesis to the first word
+                  bgWords[0].word = `${bgWords[0].word.trimStart()}`;
+
+                  // Add closing parenthesis to the last word
+                  const lastBgWordIndex = bgWords.length - 1;
+                  bgWords[lastBgWordIndex].word = `${bgWords[
+                    lastBgWordIndex
+                  ].word.trimEnd()} `;
+
+                  // Append these processed words to the main line
+                  mainLine.words.push(...bgWords);
+                }
+                // --- MODIFIED SECTION END ---
+              } else {
+                // Regular timed word
+                mainLine.words.push({
+                  startTime: parseTimestamp(item.begin) ?? 0,
+                  endTime: parseTimestamp(item.end) ?? 0,
+                  word: IsPartOfWord(pContent, i) ? `${text}` : `${text} `,
+                  romanWord: '',
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // --- 3. Post-processing ---
+      // The old logic for trimming parentheses from separate BG lines is no longer needed.
+
+      // Map iTunes word-by-word transliterations
+      lineKeyMap.forEach(({ index, key }) => {
+        const line = result.lines[index];
+        const pieces = itunesTransliterationPieces.get(key);
+
+        if (line && !line.isBG && pieces) {
+          const wordIndices = line.words
+            .map((w, i) => (w.word ? i : -1))
+            .filter((i) => i !== -1);
+
+          if (wordIndices.length === 0 || pieces.length === 0) return;
+
+          let finalPieces = [...pieces];
+          if (finalPieces.length > wordIndices.length) {
+            const extras = finalPieces
+              .splice(wordIndices.length - 1)
+              .join(' ');
+            finalPieces.push(extras);
+          }
+
+          wordIndices.forEach((wordIndex, i) => {
+            if (i < finalPieces.length) {
+              line.words[wordIndex].romanWord = finalPieces[i];
+            }
+          });
+        }
+      });
+
+      // Add interludes for long pauses between lines
+      if (result.lines.length > 0) {
+        const linesWithInterludes: LyricLine[] = [];
+        for (let i = 0; i < result.lines.length; i++) {
+          const currentLine = result.lines[i];
+          linesWithInterludes.push(currentLine);
+
+          // Check for a gap between the current line and the next one
+          const nextLine = result.lines[i + 1];
+          if (nextLine) {
+            const timeGap = nextLine.startTime - currentLine.endTime;
+            if (timeGap >= ADD_INTERLUDE_MS_SPACE) {
+              const interludeLine: LyricLine = {
+                startTime: currentLine.endTime,
+                endTime: nextLine.startTime,
+                words: [
+                  {
+                    startTime: currentLine.endTime,
+                    endTime: (currentLine.endTime + 1),
+                    word: INTERLUDE_CHARACTER,
+                    romanWord: '',
+                  },
+                ],
+                isDuet: false,
+                isBG: false,
+                translatedLyric: '',
+                romanLyric: '',
+              };
+              linesWithInterludes.push(interludeLine);
+            }
+          }
+        }
+        result.lines = linesWithInterludes;
+      }
+
+      resolve(result);
+    } catch (error: any) {
+      reject(new Error(`XML parsing error: ${error.message}`));
+    }
+  });
+}

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -13,7 +13,7 @@ import { Spicetify } from "@spicetify/bundler";
 
 export const LyricsStore = GetExpireStore<any>(
     "SpicyLyrics_LyricsStore",
-    8,
+    10,
     {
         Unit: "Days",
         Duration: 3
@@ -21,6 +21,9 @@ export const LyricsStore = GetExpireStore<any>(
 )
 
 export default async function fetchLyrics(uri: string) {
+
+    const IsSpicyRenderer = Defaults.LyricsRenderer === "Spicy";
+
     //if (!document.querySelector("#SpicyLyricsPage")) return;
     const LyricsContent = document.querySelector("#SpicyLyricsPage .LyricsContainer .LyricsContent") ?? undefined;
     if (LyricsContent?.classList.contains("offline")) {
@@ -189,7 +192,7 @@ export default async function fetchLyrics(uri: string) {
         // const providerLyrics = JSON.parse(lyricsText);
         const lyrics = JSON.parse(lyricsText);
         
-        await ProcessLyrics(lyrics);
+        (IsSpicyRenderer ? await ProcessLyrics(lyrics) : null)
 
         storage.set("currentLyricsData", JSON.stringify(lyrics));
         storage.set("currentlyFetching", "false");
@@ -327,6 +330,7 @@ async function noLyricsMessage(Cache = true, LocalStorage = true) {
     return {
         Type: "Static",
         id: SpotifyPlayer.GetId() ?? '',
+        noLyrics: true,
         Lines: [
             {
                 Text: "No Lyrics Found"

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -115,6 +115,12 @@ function generalSettings(SettingsSection: any) {
         storage.set("lockedMediaBox", settings.getFieldValue("lock_mediabox") as string)
     });
 
+    settings.addDropDown("lyrics-renderer", "Lyrics Renderer", ["Spicy Lyrics (Default) (Stable)", "AML Lyrics (Experimental) (Unstable)"], Defaults.LyricsRenderer_Default, () => {
+        const value = settings.getFieldValue("lyrics-renderer") as string;
+        const processedValue = (value === "Spicy Lyrics (Default) (Stable)" ? "Spicy" : (value === "AML Lyrics (Experimental) (Unstable)" ? "aml-lyrics" : "Spicy"))
+        storage.set("lyricsRenderer", processedValue);
+    });
+
     settings.addButton("save-n-reload", "Save your current settings and reload.", "Save & Reload", () => {
         window.location.reload();
     });

--- a/tasks/config.ts
+++ b/tasks/config.ts
@@ -1,3 +1,3 @@
 export const ProjectName = "spicy-lyrics";
 
-export const ProjectVersion = "5.10.9";
+export const ProjectVersion = "5.11.0";


### PR DESCRIPTION
- Add new "AML Lyrics" Lyrics Renderer
  - The same Lyrics renderer as from the "AMLL Tool" (but modified a little, with a custom parser)
- Fixed the Spotify Canvas video in the NPV (Now Playing View) being fully visible, and not correctly faded
  - Now it also smoothly reveals the video on hover
- Fixed some styling issues
- Fixed some code issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Experimental “AML Lyrics” renderer with TTML support and playback sync.
  - New Settings option to choose lyrics renderer (Spicy default vs AML experimental).
  - Sidebar mode for lyrics view; lyric playback resets on page change.

- Style
  - Separate styling for Spicy vs non-Spicy renderer with refined padding, transitions, and fullscreen/compact behaviors.
  - Romanization toggle now shows only with Spicy renderer and available data.
  - Video brightness/hover tweaks; canvas background visuals temporarily disabled.

- Chores
  - Dependency updates and configuration adjustments.
  - Version bumped to 5.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->