### PR TITLE
Fix local TTML support for local Spotify songs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -997,15 +997,19 @@ async function main() {
         }
         lastTimeout = setTimeout(async () => {
           const currentSongLyrics = $currentLyricsData.get();
+          const currentUri = SpotifyPlayer.GetUri();
+          const currentTrackKey = currentUri?.startsWith("spotify:local:")
+            ? currentUri
+            : SpotifyPlayer.GetId();
+
           if (
             currentSongLyrics &&
-            currentSongLyrics !== `NO_LYRICS:${SpotifyPlayer.GetId()}`
+            currentSongLyrics !== `NO_LYRICS:${currentTrackKey}`
           ) {
             const parsedLyrics = JSON.parse(currentSongLyrics);
-            if (parsedLyrics?.id !== SpotifyPlayer.GetId()) {
-              const refetchUri = SpotifyPlayer.GetUri();
-              if (refetchUri) {
-                fetchLyrics(refetchUri).then(ApplyLyrics);
+            if (parsedLyrics?.id !== currentTrackKey) {
+              if (currentUri) {
+                fetchLyrics(currentUri).then(ApplyLyrics);
               }
             }
           }

--- a/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
+++ b/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
@@ -39,10 +39,7 @@ export default function UploadTTMLModal({ onBack, onDone }: UploadTTMLModalProps
       return;
     }
 
-    if (uri.startsWith("spotify:local:")) {
-      toast.warning("Local TTML files are not available on local songs", { duration: 5000 });
-      return;
-    }
+    const cacheId = uri.startsWith("spotify:local:") ? uri : SpotifyPlayer.GetId();
 
     setUploading(true);
 
@@ -74,7 +71,7 @@ export default function UploadTTMLModal({ onBack, onDone }: UploadTTMLModalProps
           }
           const dataToSave = {
             ...result?.Result,
-            id: SpotifyPlayer.GetId(),
+            id: cacheId,
           };
           await ProcessLyrics(dataToSave);
           $currentLyricsData.set(JSON.stringify(dataToSave));

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -83,7 +83,11 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     return ["unknown-track", 400];
   }
 
-  const trackId = uri.split(":")[2];
+  const isLocalTrack = uri.startsWith("spotify:local:");
+  // Normal Spotify tracks use their Spotify track ID. Local tracks do not have
+  // a real track ID here (uri.split(":")[2] is only the URL-encoded artist),
+  // so use the full local URI as the cache/local-lyrics key.
+  const trackId = isLocalTrack ? uri : uri.split(":")[2];
 
   if ($currentlyFetching.get()) {
     $currentlyFetching.set(false);
@@ -132,11 +136,10 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     return [lyricsData, 200];
   }
 
-  // Local files have no real track id (uri.split(":")[2] is the URL-encoded
-  // artist name), so they can't be looked up in LyricsStore or fetched from the
-  // API. Bail out here — after LocalLyricsManager.get() (which serves any
-  // user-uploaded TTML) but before the meaningless remote cache read.
-  if (uri.startsWith("spotify:local:")) {
+  // Local files cannot be looked up in LyricsStore or fetched from the API.
+  // Bail out here after LocalLyricsManager.get(), which serves user-uploaded
+  // TTML for local files by their full spotify:local URI.
+  if (isLocalTrack) {
     $currentlyFetching.set(false);
     return ["local-track", 400];
   }


### PR DESCRIPTION
Tested locally on a Spotify local file. The TTML upload now works for spotify:local tracks, and the repeated lyrics reload/stutter issue is fixed by using the current local URI as the lyrics key.