### PR TITLE
fix: mirror the lyrics-page background in the Now Playing View (all modes)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -547,6 +547,9 @@ async function main() {
     let lastNowPlayingBarElement: HTMLElement | null = null;
     let nowPlayingBarObserver: MutationObserver | null = null;
     let nowPlayingBarMutationTimeout: ReturnType<typeof setTimeout> | null = null;
+    // makes the next apply ignore the "cover unchanged" skip (set on a song change)
+    // kept across the debounce so a mutation reschedule doesn't lose it
+    let nowPlayingBarForcePending = false;
 
     const getNowPlayingBarElement = () =>
       document.querySelector<HTMLElement>(".Root__right-sidebar aside.NowPlayingView") ??
@@ -554,13 +557,16 @@ async function main() {
         `.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.main-nowPlayingView-coverArtContainer)`
       );
 
-    const scheduleNowPlayingBarDynamicBackgroundApply = () => {
+    const scheduleNowPlayingBarDynamicBackgroundApply = (force = false) => {
+      if (force) nowPlayingBarForcePending = true;
       if (nowPlayingBarMutationTimeout) {
         clearTimeout(nowPlayingBarMutationTimeout);
       }
       nowPlayingBarMutationTimeout = setTimeout(() => {
         nowPlayingBarMutationTimeout = null;
-        void applyDynamicBackgroundToNowPlayingBar(SpotifyPlayer.GetCover("large"));
+        const doForce = nowPlayingBarForcePending;
+        nowPlayingBarForcePending = false;
+        void applyDynamicBackgroundToNowPlayingBar(SpotifyPlayer.GetCover("large"), doForce);
       }, 50);
     };
 
@@ -601,7 +607,9 @@ async function main() {
         kawarpInstance.dispose();
         KawarpMap.delete("npvbg");
       }
-      nowPlayingBar?.querySelector<HTMLElement>(".spicy-dynamic-bg")?.remove();
+      // remove all bg elements not just the first
+      // mode switches and the static cross-fade can leave a stale layer that blocks updates
+      nowPlayingBar?.querySelectorAll<HTMLElement>(".spicy-dynamic-bg").forEach((el) => el.remove());
       nowPlayingBar?.classList.remove("spicy-dynamic-bg-in-this");
       lastNowPlayingBarElement = null;
       lastImgUrl = null;
@@ -670,9 +678,10 @@ async function main() {
       }
     );
 
-    async function applyDynamicBackgroundToNowPlayingBar(coverUrl: string | undefined) {
+    async function applyDynamicBackgroundToNowPlayingBar(coverUrl: string | undefined, force = false) {
       if (!$showNpvDynamicBg.get()) return;
-      if (SpotifyPlayer.GetContentType() === "unknown" || SpotifyPlayer.IsDJ()) return;
+      // don't skip on IsDJ() here it's only true on DJ narration segments
+      // toggling on it flickered the bg, so DJ is handled by the cover-art check below
       if (!coverUrl) return;
       const nowPlayingBar = getNowPlayingBarElement();
       const topContainer = getTopContainerElement();
@@ -685,13 +694,36 @@ async function main() {
           return;
         }
         lastNowPlayingBarElement = nowPlayingBar;
-        if (coverUrl === lastImgUrl) return;
+
+        // no cover art means DJ is playing (it shows an "Up next" card)
+        // the CSS hides the bg then so skip building it here too, and don't clean up or it churns every DJ segment
+        // (only .NowPlayingView reaches this, #Desktop_PanelContainer_Id is null during DJ and cleaned above)
+        if (!nowPlayingBar.querySelector(".main-nowPlayingView-coverArtContainer")) {
+          return;
+        }
+
+        // Spotify can wipe our element when it re-renders the panel
+        // if the cover is unchanged but our element is gone re-add it, only skip if it's still there
+        const hasExistingBg = Boolean(nowPlayingBar.querySelector(".spicy-dynamic-bg"));
+        if (!force && coverUrl === lastImgUrl && hasExistingBg) return;
+
+        // element was wiped so drop the old Kawarp instance or the recreated canvas leaks a WebGL context
+        // (no Kawarp in color/static modes)
+        if (!hasExistingBg) {
+          const staleKawarp = KawarpMap.get("npvbg");
+          if (staleKawarp) {
+            staleKawarp.dispose();
+            KawarpMap.delete("npvbg");
+          }
+        }
 
         nowPlayingBar.classList.add("spicy-dynamic-bg-in-this");
 
-        await ApplyDynamicBackground(nowPlayingBar, "npvbg");
-
+        // set lastImgUrl before the await, appending the element wakes the observer which reschedules us
+        // doing it now lets that re-run short-circuit instead of firing a second color request
+        // a song change still refreshes via force
         lastImgUrl = coverUrl;
+        await ApplyDynamicBackground(nowPlayingBar, "npvbg");
       } catch (error) {
         dynamicBgLogger.error("Failed applying dynamic background to now playing bar", error);
       }
@@ -703,6 +735,13 @@ async function main() {
       } else {
         scheduleNowPlayingBarDynamicBackgroundApply();
       }
+    });
+
+    // rebuild the sidebar bg when the mode changes (canvas vs static/color element)
+    // tear the old one down first so it can't stay frozen on the old track
+    $staticBackgroundMode.listen(() => {
+      CleanupNowBarDynamicBgLets();
+      scheduleNowPlayingBarDynamicBackgroundApply();
     });
 
     startNowPlayingBarObserver();
@@ -762,7 +801,9 @@ async function main() {
       }
 
       try {
-        void scheduleNowPlayingBarDynamicBackgroundApply();
+        // force a refresh on song change so color mode re-fetches this track's colors
+        // even if the cover URL happens to match
+        void scheduleNowPlayingBarDynamicBackgroundApply(true);
       } catch (err) {
         dynamicBgLogger.error("Failed applying dynamic background to now playing bar", err);
       }

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -159,7 +159,9 @@ export default async function ApplyDynamicBackground(element: HTMLElement, tag?:
         dynamicBg.style.setProperty("--OverlayColor", COLOR_BG_FALLBACK_RGB);
         element.appendChild(dynamicBg);
       }
-      cachedColorBackgroundEl = dynamicBg;
+      // keep this pointing at the page's color bg only
+      // the songchange flash below uses it and we don't want it flashing the sidebar element
+      if (tag !== "npvbg") cachedColorBackgroundEl = dynamicBg;
 
       // Local tracks aren't hosted on Spotify, so we can't derive dynamic colors
       // from their artwork — keep the plain black background instead.
@@ -443,7 +445,6 @@ Global.Event.listen("playback:playpause", (e: { data?: { isPaused?: boolean } })
   applyPlayPauseAnimationSpeed(!!e?.data?.isPaused);
 });
 
-// TODO: Make this also remove the NPV dynamic bg when we switch to staticBackground mode, as that should be removed.
 const reapplyPageBackground = () => {
   const contentBox = PageContainer?.querySelector<HTMLElement>(".ContentBox");
   if (!contentBox) return;

--- a/src/css/DynamicBG/spicy-dynamic-bg.css
+++ b/src/css/DynamicBG/spicy-dynamic-bg.css
@@ -24,6 +24,8 @@ aside .spicy-dynamic-bg {
 .spicy-dynamic-bg-in-this {
   overflow: hidden;
   position: relative;
+  /* stacking context so the bg (z-index:0) stays below the lifted content (z-index:1) and scoped to this panel */
+  isolation: isolate;
 }
 
 /* Special styling for side panel */
@@ -78,7 +80,9 @@ div.main-nowPlayingView-contextItemInfo:has(.main-trackInfo-container)::after,
   display: none !important;
 }
 
-aside:has(.spicy-dynamic-bg) > div,
+/* lift the panel content above the background
+   exclude the bg elements themselves, color/static modes are <div>s that would otherwise get pulled into the content layer */
+aside:has(.spicy-dynamic-bg) > div:not(.spicy-dynamic-bg),
 aside:has(.spicy-dynamic-bg) .AAdBM1nhG73supMfnYX7,
 aside:has(.spicy-dynamic-bg) .iHa_q9pq4un3VNRQgwTx {
   z-index: 1;
@@ -86,7 +90,7 @@ aside:has(.spicy-dynamic-bg) .iHa_q9pq4un3VNRQgwTx {
 }
 
 /* Low quality mode styles - kept unchanged as requested */
-#SpicyLyricsPage .spicy-dynamic-bg.StaticBackground {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.StaticBackground {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -96,10 +100,10 @@ aside:has(.spicy-dynamic-bg) .iHa_q9pq4un3VNRQgwTx {
   will-change: transform, filter;
 }
 
-#SpicyLyricsPage .spicy-dynamic-bg.StaticBackground.transition_In {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.StaticBackground.transition_In {
   animation: SDB_StaticBG_T_IN forwards 850ms cubic-bezier(0.66, 0, 0.34, 1);
 }
-#SpicyLyricsPage .spicy-dynamic-bg.StaticBackground.transition_Out {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.StaticBackground.transition_Out {
   animation: SDB_StaticBG_T_OUT forwards 850ms cubic-bezier(0.66, 0, 0.34, 1);
 }
 
@@ -128,13 +132,21 @@ body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar
   display: none;
 }
 
+/* hide the sidebar bg during DJ (the panel shows an "Up next" card, no cover art)
+   keying on the missing cover-art container in CSS means no flicker no strip */
+.Root__right-sidebar
+  aside.spicy-dynamic-bg-in-this:not(:has(.main-nowPlayingView-coverArtContainer))
+  .spicy-dynamic-bg {
+  display: none !important;
+}
+
 .Root__right-sidebar
   aside#Desktop_PanelContainer_Id:has(.spicy-dynamic-bg)
   .main-buddyFeed-scrollBarContainer {
   z-index: 1;
 }
 
-#SpicyLyricsPage .spicy-dynamic-bg.ColorBackground {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.ColorBackground {
   /* background-color: rgba(0, 0, 0, 0.25); */
   /* background: linear-gradient(var(--ColorBackgroundRotation), var(--DesaturatedColor), var(--VibrantColor), var(--DarkVibrantColor), var(--BaseColor), var(--DesaturatedColor)); */
   background-color: rgba(var(--MinContrastColor));
@@ -149,7 +161,7 @@ body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar
   initial-value: 0deg;
 } */
 
-#SpicyLyricsPage .spicy-dynamic-bg.ColorBackground::before {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.ColorBackground::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -161,7 +173,7 @@ body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar
   transition: background-color 1.5s;
 }
 
-#SpicyLyricsPage .spicy-dynamic-bg.ColorBackground::after {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.ColorBackground::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -172,18 +184,24 @@ body:has(#SpicyLyricsPage.Fullscreen) .Root__right-sidebar
   z-index: 5;
 }
 
-#SpicyLyricsPage .spicy-dynamic-bg.CanvasBackground {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.CanvasBackground {
   width: 100%;
   height: 100%;
 }
 
-#SpicyLyricsPage .spicy-dynamic-bg.CanvasBackground video {
+:is(#SpicyLyricsPage, .spicy-dynamic-bg-in-this) .spicy-dynamic-bg.CanvasBackground video {
   width: 100%;
   height: 100%;
 }
 
 #SpicyLyricsPage .spicy-dynamic-bg.ColorBackground {
   z-index: -1 !important;
+}
+
+/* sidebar content is lifted to z-index:1 so the bg sits at 0
+   (-1 like the page would drop it behind the panel's opaque content and hide the color) */
+.spicy-dynamic-bg-in-this .spicy-dynamic-bg.ColorBackground {
+  z-index: 0 !important;
 }
 
 .NowPlayingView .main-nowPlayingView-headerCloseButton {


### PR DESCRIPTION
## Problem

The Now Playing View sidebar background only worked in the animated ("off") mode. With Static Background set to Color / Cover Art / Auto / Artist Header, the sidebar didn't mirror the lyrics page — it stayed frozen on the previous track and never updated.

**Regular modes**

| Before | After |
| --- | --- |
| <img width="350" alt="prev" src="https://github.com/user-attachments/assets/344e2894-e634-4d26-a210-60c6615c238f" /> | <img width="350" alt="after" src="https://github.com/user-attachments/assets/a333e7bb-10ff-4859-a78a-81cc3f5565c3" /> |

**DJ**

| Before | After |
| --- | --- |
| <img width="350" alt="dj-before" src="https://github.com/user-attachments/assets/a4fc67d1-e211-446b-9f51-8b1dd2cfb0e5" /> | <img width="350" alt="dj-after" src="https://github.com/user-attachments/assets/ef3f03be-cd96-4c61-a70d-480be49424a2" /> |



## Fix

- Render the non-"off" backgrounds in the sidebar too, not just the lyrics page
- Fix the color layer's z-index so it isn't hidden behind the panel content
- Update the sidebar on every track change, and rebuild it if Spotify wipes it
- Keep it in sync with the background-mode setting
- Hide it during the DJ (no cover art there) so there's no leftover strip or flicker
