### PR TITLE
fix(sidebar): restore sidebar lyrics (npv) and resizer

### DIFF
--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -151,12 +151,24 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
   spicyLyricsPageObserver.observe(parent, { childList: true });
 
   // Observe for new <aside> being added to the parent container
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
   spicySidebarAsideObserver = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       for (const n of Array.from(mutation.addedNodes)) {
         if (n instanceof HTMLElement && n.tagName === "ASIDE") {
           if (n.id === "SpicyLyricsPage" || n.querySelector("#SpicyLyricsPage")) continue;
-          if (Date.now() - openTime < 500) continue;
+          const elapsed = Date.now() - openTime;
+          if (elapsed < 500) {
+            // Defer cleanup until grace window expires instead of dropping the event
+            if (graceTimer !== null) clearTimeout(graceTimer);
+            graceTimer = setTimeout(() => {
+              graceTimer = null;
+              cleanupSidebarLyricsObservers();
+              cleanupFn();
+            }, 500 - elapsed);
+            continue;
+          }
+          if (graceTimer !== null) { clearTimeout(graceTimer); graceTimer = null; }
           cleanupSidebarLyricsObservers();
           cleanupFn();
           return;

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -18,7 +18,8 @@ const getDesktopPanelContainer = () =>
 const getRightSidebarParentContainer = () =>
   document.querySelector<HTMLElement>(".Root__right-sidebar > div:first-of-type") ??
   document.querySelector<HTMLElement>(".Root__right-sidebar .XOawmCGZcQx4cesyNfVO") ??
-  document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a");
+  document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a") ??
+  document.querySelector<HTMLElement>(".Root__right-sidebar");
 const getQueueContainerElement = () =>
   document.querySelector<HTMLElement>(
     ".Root__right-sidebar > div:first-of-type:has(.v5CVyjR4gInbbJpm, .RSJZvcFNF4XzkvK4S1F9)"
@@ -31,7 +32,9 @@ const getQueueContainerElement = () =>
   ) ??
   document.querySelector<HTMLElement>(
     ".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a:not(:has(.Ot1yAtVbjD2owYqmw6BK)):has(.main-nowPlayingView-mainContainer.main-actionBar-ActionBarContainer)"
-  );
+  ) ??
+  document.querySelector<HTMLElement>(".Root__right-sidebar > div:first-of-type") ??
+  document.querySelector<HTMLElement>(".Root__right-sidebar");
 const getDevicesContainerElement = () =>
   document.querySelector<HTMLElement>(
     ".Root__right-sidebar > div:first-of-type:has(.OINH5zA0pQyzffwo, .FNi2RAtuzIc9THq8HYIW):not(:has(.main-nowPlayingView-coverArtContainer))"
@@ -131,6 +134,8 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
   const parent = spicyLyricsEl.parentElement;
   if (!parent) return;
 
+  const openTime = Date.now();
+
   // Observe for removal of #SpicyLyricsPage
   spicyLyricsPageObserver = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
@@ -150,6 +155,8 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
     for (const mutation of mutations) {
       for (const n of Array.from(mutation.addedNodes)) {
         if (n instanceof HTMLElement && n.tagName === "ASIDE") {
+          if (n.id === "SpicyLyricsPage" || n.querySelector("#SpicyLyricsPage")) continue;
+          if (Date.now() - openTime < 500) continue;
           cleanupSidebarLyricsObservers();
           cleanupFn();
           return;
@@ -161,8 +168,59 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
 }
 
 
+let resizerAbortController: AbortController | null = null;
+
+export function SetupResizerDragListener() {
+  if (resizerAbortController) {
+    resizerAbortController.abort();
+    resizerAbortController = null;
+  }
+
+  const resizer = document.querySelector<HTMLElement>(".LayoutResizer__resize-bar.LayoutResizer__inline-start");
+  const top = document.querySelector<HTMLElement>(".Root__top-container");
+  const right = document.querySelector<HTMLElement>(".Root__right-sidebar");
+  if (!resizer || !top || !right) return;
+
+  const controller = new AbortController();
+  resizerAbortController = controller;
+  const { signal } = controller;
+
+  let isDragging = false;
+  let startX = 0;
+  let startWidth = 0;
+
+  resizer.addEventListener("pointerdown", (e: PointerEvent) => {
+    if (!isSpicySidebarMode) return;
+    isDragging = true;
+    startX = e.clientX;
+    startWidth = right.getBoundingClientRect().width;
+    try { resizer.setPointerCapture(e.pointerId); } catch (_err) {}
+    e.stopPropagation();
+    e.preventDefault();
+  }, { capture: true, signal });
+
+  resizer.addEventListener("pointermove", (e: PointerEvent) => {
+    if (!isDragging || !isSpicySidebarMode) return;
+    const deltaX = startX - e.clientX;
+    const newWidth = Math.max(280, Math.min(850, startWidth + deltaX));
+    top.style.setProperty("--right-sidebar-width", `${newWidth}px`, "important");
+    top.style.setProperty("grid-template-columns", `auto 1fr ${newWidth}px`, "important");
+  }, { capture: true, signal });
+
+  const stopDrag = (e: PointerEvent) => {
+    if (isDragging) {
+      isDragging = false;
+      try { resizer.releasePointerCapture(e.pointerId); } catch (_err) {}
+    }
+  };
+
+  resizer.addEventListener("pointerup", stopDrag, { capture: true, signal });
+  resizer.addEventListener("pointercancel", stopDrag, { capture: true, signal });
+}
+
 function runPageOpenWithCleanup(parentContainer: HTMLElement) {
   PageView.Open(parentContainer, true);
+  SetupResizerDragListener();
   // After opening, observe #SpicyLyricsPage for removal and cleanup
   // Use setTimeout to wait for DOM update
   setTimeout(() => {

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -114,8 +114,13 @@ let onOpen_wasThingOpen: string | undefined;
 // --- Helper to observe removal of #SpicyLyricsPage ---
 let spicyLyricsPageObserver: MutationObserver | null = null;
 let spicySidebarAsideObserver: MutationObserver | null = null;
+let graceTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function cleanupSidebarLyricsObservers() {
+  if (graceTimer !== null) {
+    clearTimeout(graceTimer);
+    graceTimer = null;
+  }
   if (spicyLyricsPageObserver) {
     try {
       spicyLyricsPageObserver.disconnect();
@@ -159,7 +164,7 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
   spicyLyricsPageObserver.observe(parent, { childList: true });
 
   // Observe for new <aside> being added to the parent container
-  let graceTimer: ReturnType<typeof setTimeout> | null = null;
+  graceTimer = null;
   spicySidebarAsideObserver = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       for (const n of Array.from(mutation.addedNodes)) {

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -168,7 +168,22 @@ function observeSpicyLyricsPageRemoval(cleanupFn: () => void) {
 }
 
 
+function cleanupGridOverride() {
+  const top = document.querySelector<HTMLElement>(".Root__top-container");
+  if (top) {
+    top.style.removeProperty("--right-sidebar-width");
+    top.style.removeProperty("grid-template-columns");
+  }
+}
+
 let resizerAbortController: AbortController | null = null;
+
+function teardownResizerDragListener() {
+  if (resizerAbortController) {
+    resizerAbortController.abort();
+    resizerAbortController = null;
+  }
+}
 
 export function SetupResizerDragListener() {
   if (resizerAbortController) {
@@ -313,6 +328,8 @@ export async function CloseSidebarLyrics(auto: boolean = false) {
   currentNPVWhentil = null;
   
   cleanupSidebarLyricsObservers();
+  cleanupGridOverride();
+  teardownResizerDragListener();
 
   // console.log("[Spicy Lyrics Debug] PageView.Destroy()");
   await PageView.Destroy();
@@ -376,6 +393,8 @@ export function SetupQueueButtonListener() {
         spicyLyricsPageObserver = null;
       }
       await PageView.Destroy();
+      cleanupGridOverride();
+      teardownResizerDragListener();
       appendClosed();
       isSpicySidebarMode = false;
       button.click();

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -15,11 +15,19 @@ const getDesktopPanelContainer = () =>
   document.querySelector<HTMLElement>(
     `.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.main-nowPlayingView-coverArtContainer)`
   );
-const getRightSidebarParentContainer = () =>
-  document.querySelector<HTMLElement>(".Root__right-sidebar > div:first-of-type") ??
-  document.querySelector<HTMLElement>(".Root__right-sidebar .XOawmCGZcQx4cesyNfVO") ??
-  document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a") ??
-  document.querySelector<HTMLElement>(".Root__right-sidebar");
+const getRightSidebarParentContainer = () => {
+  const container =
+    document.querySelector<HTMLElement>(".Root__right-sidebar > div:first-of-type") ??
+    document.querySelector<HTMLElement>(".Root__right-sidebar .XOawmCGZcQx4cesyNfVO") ??
+    document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a") ??
+    document.querySelector<HTMLElement>(".Root__right-sidebar");
+  // Fallback lands on .Root__right-sidebar itself which lacks position: relative,
+  // so absolute-positioned #SpicyLyricsPage would escape the sidebar bounds.
+  if (container?.classList.contains("Root__right-sidebar")) {
+    container.style.position = "relative";
+  }
+  return container;
+};
 const getQueueContainerElement = () =>
   document.querySelector<HTMLElement>(
     ".Root__right-sidebar > div:first-of-type:has(.v5CVyjR4gInbbJpm, .RSJZvcFNF4XzkvK4S1F9)"
@@ -185,6 +193,11 @@ function cleanupGridOverride() {
   if (top) {
     top.style.removeProperty("--right-sidebar-width");
     top.style.removeProperty("grid-template-columns");
+  }
+  // Remove the inline position: relative set by the fallback in getRightSidebarParentContainer
+  const sidebar = document.querySelector<HTMLElement>(".Root__right-sidebar");
+  if (sidebar) {
+    sidebar.style.removeProperty("position");
   }
 }
 

--- a/src/css/default.css
+++ b/src/css/default.css
@@ -399,11 +399,33 @@ body.SpicySidebarLyrics__Active .x-settings-row:has([id="settings.showFriendActi
   display: none !important;
 }
 
+body.SpicySidebarLyrics__Active .Root__top-container {
+  grid-template-columns: auto 1fr max(320px, calc(var(--right-sidebar-width, 380) * 1px)) !important;
+}
+
+body.SpicySidebarLyrics__Active .Root__right-sidebar {
+  display: flex !important;
+  flex-direction: column !important;
+  min-width: 0 !important;
+  width: 100% !important;
+}
+
+body.SpicySidebarLyrics__Active .Root__right-sidebar > div:first-of-type {
+  display: flex !important;
+  flex-direction: column !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  flex: 1 !important;
+  position: relative !important;
+  height: 100% !important;
+}
+
 body.SpicySidebarLyrics__Active .Root__right-sidebar .XOawmCGZcQx4cesyNfVO > :not(#SpicyLyricsPage),
 body.SpicySidebarLyrics__Active
   .Root__right-sidebar
   .oXO9_yYs6JyOwkBn8E4a
-  > :not(#SpicyLyricsPage) {
+  > :not(#SpicyLyricsPage),
+body.SpicySidebarLyrics__Active .Root__right-sidebar > div:first-of-type > :not(#SpicyLyricsPage) {
   display: none !important;
 }
 
@@ -422,6 +444,13 @@ body.SpicySidebarLyrics__Active #SpicyLyricsPage .NowBar {
 body.SpicySidebarLyrics__Active #SpicyLyricsPage {
   --LyricsLeftSidePadding: 12cqw !important;
   --LyricsRightSidePadding: 7.5cqw !important;
+  height: 100% !important;
+  width: 100% !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
 }
 
 #SpicyLyricsPage.SidebarTransition__Opening {


### PR DESCRIPTION
This fix restores the functionality of the lyrics in the sidebar (Now Playing View / `.Root__right-sidebar`), introduces native resize handle drag support via pointer events, and adds Peek NPV feature compatibility.

### Key Changes:
- **Sidebar Container Selectors (`SidebarLyrics.ts`):** Added fallback selectors targeting `.Root__right-sidebar` and its child divs to ensure reliable rendering within the updated Spotify DOM structure.
- **MutationObserver Robustness:** Implemented a timestamp check (500ms delay) and specific ID checks (`#SpicyLyricsPage`) to prevent premature unmounting of the lyrics view during sidebar transitions.
- **Native Sidebar Resizing (`SetupResizerDragListener`):** Registered a pointer-down/move/up listener on `.LayoutResizer__resize-bar` to dynamically adjust the `--right-sidebar-width` and `grid-template-columns` CSS properties on `.Root__top-container`.
- **CSS Styles (`default.css`):** Applied absolute positioning to `#SpicyLyricsPage` and forced flexbox layout on the right sidebar container to properly contain the newly resized layout elements.