### PR TITLE
[Feature]: Add the ability to prevent lyrics from scrolling up

### DIFF
--- a/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
+++ b/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
@@ -4,6 +4,7 @@ import {
   $minimalLyricsMode,
   $simpleLyricsMode,
   $simpleLyricsModeRenderingType,
+  $allowScrollUp
 } from "../../../utils/stores.ts";
 import { matches, Row, Select, SectionTitle, Toggle } from "./components.tsx";
 
@@ -19,14 +20,16 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
   const simpleLyricsMode = useStore($simpleLyricsMode);
   const simpleLyricsModeRenderingType = useStore($simpleLyricsModeRenderingType);
   const minimalLyricsMode = useStore($minimalLyricsMode);
+  const allowScrollUp = useStore($allowScrollUp);
 
   if (sectionFilter !== "All" && sectionFilter !== SECTION_NAME) return null;
 
   const r1 = matches(query, "Simple Lyrics Mode", "Remove extra visual effects from lyrics");
   const r2 = matches(query, "Simple Mode: Text Animation Style", "How lyrics text transitions are rendered in Simple Lyrics Mode.");
   const r3 = matches(query, "Minimal Lyrics Mode", "Hides sung lyrics lines in Fullscreen and Cinema Mode");
+  const r4 = matches(query, "Allow Scrolling Up", "Allow lyrics to scroll back up when the active line is above the last one");
 
-  if (!r1 && !r2 && !r3) return null;
+  if (!r1 && !r2 && !r3 && !r4) return null;
 
   return (
     <>
@@ -60,6 +63,15 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
           description="Hides sung lyrics lines in Fullscreen and Cinema Mode"
         >
           <Toggle checked={minimalLyricsMode} onChange={(v) => $minimalLyricsMode.set(v)} />
+        </Row>
+      )}
+
+      {r4 && (
+        <Row
+          label="Allow Scrolling Up"
+          description="Allow lyrics to scroll back up when the active line is above the last one"
+        >
+          <Toggle checked={allowScrollUp} onChange={(v) => $allowScrollUp.set(v)} />
         </Row>
       )}
     </>

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -22,6 +22,9 @@ type EnhancedLyricsItem = LyricsLineWithIndex | LyricsSyllableWithIndex;
 // Define proper types for variables
 let lastLine: HTMLElement | null = null;
 let lastLineIndex: number | null = null;
+// The lyrics array that lastLineIndex refers to. When the active lyrics swap
+// (new track / type change) this identity changes, invalidating the stale index.
+let lastLinesRef: LyricsLine[] | LyricsSyllable[] | null = null;
 let isUserScrolling = false;
 let lastUserScrollTime = 0;
 let lastPosition: number = 0;
@@ -230,6 +233,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     lastLine = scrollToLine;
     const forceScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
     lastLineIndex = forceScrollLineIndex ?? null;
+    lastLinesRef = Lines;
     ScrollTo(
       container,
       scrollToLine,
@@ -258,6 +262,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     lastLine = scrollToLine;
     const smoothScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
     lastLineIndex = smoothScrollLineIndex ?? null;
+    lastLinesRef = Lines;
     ScrollTo(container, scrollToLine, false, GetScrollType(), smoothScrollLineIndex);
     if (smoothForceScrollQueued) {
       smoothForceScrollQueued = false; // Reset the queue after using it
@@ -433,10 +438,13 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
         //}
         // Scroll if the line is different from the last auto-scrolled line
         const isScrollingUp =
-          lastLineIndex !== null && currentLine._LineIndex < lastLineIndex;
+          lastLineIndex !== null &&
+          lastLinesRef === Lines &&
+          currentLine._LineIndex < lastLineIndex;
         if (!isSameLine && (isScrollingUp ? $allowScrollUp.get() : true)) {
           lastLine = LineElem;
           lastLineIndex = currentLine._LineIndex;
+          lastLinesRef = Lines;
           const Scroll = () => {
             ScrollTo(container, LineElem, false, GetScrollType(), currentLine._LineIndex);
             scrolledToLastLine = false;
@@ -470,6 +478,7 @@ export function QueueSmoothForceScroll() {
 export function ResetLastLine() {
   lastLine = null;
   lastLineIndex = null;
+  lastLinesRef = null;
   lastViewportLine = null;
   lastViewportContainer = null;
   lastIsLineInViewport = false;

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -1,4 +1,4 @@
-import { $currentLyricsType, $lyricsContainerExists } from "../../utils/stores.ts";
+import { $allowScrollUp, $currentLyricsType, $lyricsContainerExists } from "../../utils/stores.ts";
 import Global from "../../components/Global/Global.ts";
 import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
@@ -21,6 +21,7 @@ type EnhancedLyricsItem = LyricsLineWithIndex | LyricsSyllableWithIndex;
 
 // Define proper types for variables
 let lastLine: HTMLElement | null = null;
+let lastLineIndex: number | null = null;
 let isUserScrolling = false;
 let lastUserScrollTime = 0;
 let lastPosition: number = 0;
@@ -228,6 +229,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     if (!scrollToLine) return;
     lastLine = scrollToLine;
     const forceScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
+    lastLineIndex = forceScrollLineIndex ?? null;
     ScrollTo(
       container,
       scrollToLine,
@@ -255,6 +257,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     if (!scrollToLine) return;
     lastLine = scrollToLine;
     const smoothScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
+    lastLineIndex = smoothScrollLineIndex ?? null;
     ScrollTo(container, scrollToLine, false, GetScrollType(), smoothScrollLineIndex);
     if (smoothForceScrollQueued) {
       smoothForceScrollQueued = false; // Reset the queue after using it
@@ -429,8 +432,11 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
         }
         //}
         // Scroll if the line is different from the last auto-scrolled line
-        if (!isSameLine) {
+        const isScrollingUp =
+          lastLineIndex !== null && currentLine._LineIndex < lastLineIndex;
+        if (!isSameLine && (isScrollingUp ? $allowScrollUp.get() : true)) {
           lastLine = LineElem;
+          lastLineIndex = currentLine._LineIndex;
           const Scroll = () => {
             ScrollTo(container, LineElem, false, GetScrollType(), currentLine._LineIndex);
             scrolledToLastLine = false;
@@ -463,6 +469,7 @@ export function QueueSmoothForceScroll() {
 
 export function ResetLastLine() {
   lastLine = null;
+  lastLineIndex = null;
   lastViewportLine = null;
   lastViewportContainer = null;
   lastIsLineInViewport = false;

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -56,6 +56,7 @@ export const $minimalLyricsMode = persistAtom<boolean>("minimalLyricsMode", fals
 export const $skipSpicyFont = persistAtom<boolean>("skipSpicyFont", false);
 export const $showNpvDynamicBg = persistAtom<boolean>("showNpvDynamicBg", true);
 export const $lockedMediaBox = persistAtom<boolean>("lockedMediaBox", false);
+export const $allowScrollUp = persistAtom<boolean>("allowScrollUp", true);
 // $popupLyricsAllowed: stored as actual boolean "popupLyricsAllowed" in the settings blob.
 export const $popupLyricsAllowed = (() => {
   const initial: boolean =


### PR DESCRIPTION
This PR adds a setting in the Lyrics Display section to prevent lyrics from scrolling back up due to still ongoing lines that appear before the latest one.