### PR TITLE
Fix Logger import path casing to match the real filename

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,7 +58,7 @@ import "./utils/settings.ts";
 import SLToaster from "./components/ReactComponents/SLToaster.tsx";
 import { openSettingsPanel } from "./utils/settings.ts";
 import { exposeToWindow } from "./utils/expose.ts";
-import Logger from "./utils/logger.ts";
+import Logger from "./utils/Logger.ts";
 import Whentil from "./modules/Whentil.ts";
 import App from "./utils/app.ts";
 import { initSession } from "./utils/SessionManager/index.ts";

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -7,7 +7,7 @@ import { PageContainer } from "../Pages/PageView.ts";
 import Kawarp, { type KawarpOptions } from "@kawarp/core";
 import { BackgroundAnimationController, type AudioAnalysisData } from "./BackgroundAnimationController.ts";
 import { getDynamicAudioAnalysis } from "../../utils/audioAnalysis.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const dynamicBgLogger = new Logger("Dynamic Background");
 

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -55,7 +55,7 @@ import { NPVCardOwnsPage, DeRenderNPVCard } from "../Utils/NPVLyrics.ts";
 import { CleanUpIsByCommunity } from "../../utils/Lyrics/Applyer/Credits/ApplyIsByCommunity.tsx";
 import { OpenLyricsDBPanel } from "../../utils/openLyricsDBPanel.tsx";
 import { openSettingsPanel } from "../../utils/settings.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 import { triggerRemeasureLV } from "../../utils/Lyrics/LyricsVirtualizer.ts";
 
 const pageLogger = new Logger("Page View");

--- a/src/components/ReactComponents/SLToaster.tsx
+++ b/src/components/ReactComponents/SLToaster.tsx
@@ -2,7 +2,7 @@ import { useStore } from "@nanostores/react";
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
 import { $isGlobalNav } from "../../utils/uiState";
-import Logger from "../../utils/logger";
+import Logger from "../../utils/Logger";
 
 const toasterLogger = new Logger("Toaster");
 

--- a/src/components/Utils/NPVLyrics.ts
+++ b/src/components/Utils/NPVLyrics.ts
@@ -15,7 +15,7 @@ import Whentil from "../../modules/Whentil.ts";
 import { $npvLyricsExpanded, $npvLyricsOpen } from "../../utils/uiState.ts";
 import { $currentLyricsData, $hideNpvLyricsWhenUnavailable } from "../../utils/stores.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const cardLogger = new Logger("NPV Lyrics");
 

--- a/src/utils/API/Query.ts
+++ b/src/utils/API/Query.ts
@@ -1,6 +1,6 @@
 import Defaults from "../../components/Global/Defaults.ts";
 import Session from "../../components/Global/Session.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 export type Query = {
   operation: string;

--- a/src/utils/IntervalManager.ts
+++ b/src/utils/IntervalManager.ts
@@ -1,5 +1,5 @@
 import { Maid } from "../modules/Maid";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const intervalLogger = new Logger("Interval Manager");
 

--- a/src/utils/Lyrics/LyricsQueueRetry.ts
+++ b/src/utils/Lyrics/LyricsQueueRetry.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import Global from "../../components/Global/Global.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import ApplyLyrics from "./Global/Applyer.ts";
 import fetchLyrics, { ShowQueueLoader } from "./fetchLyrics.ts";
 

--- a/src/utils/Lyrics/LyricsVirtualizer.ts
+++ b/src/utils/Lyrics/LyricsVirtualizer.ts
@@ -5,7 +5,7 @@ import {
   observeElementOffset,
 } from "@tanstack/virtual-core";
 import { Maid } from "../../modules/Maid.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Gap scale factors relative to 1cqw (containerWidth / 100).
 // Gap is baked into each wrapper's padding-bottom so items can have

--- a/src/utils/Lyrics/ProcessLyrics.ts
+++ b/src/utils/Lyrics/ProcessLyrics.ts
@@ -5,7 +5,7 @@ import langs from "langs";
 import { RetrievePackage } from "../ImportPackage.ts";
 import * as KuromojiAnalyzer from "./KuromojiAnalyzer.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Constants
 const RomajiConverter = new Kuroshiro();

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -5,7 +5,7 @@ import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import PageView, { PageContainer } from "../../components/Pages/PageView.ts";
 import { Query } from "../API/Query.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import { LocalLyricsManager } from "./manager/index.ts";
 import { LyricsQueueRetry } from "./LyricsQueueRetry.ts";
 import { GetExpireStore } from "../../modules/Store.ts";

--- a/src/utils/Lyrics/manager/index.ts
+++ b/src/utils/Lyrics/manager/index.ts
@@ -1,5 +1,5 @@
 import { dbPromise, ObjectStores } from "../../db";
-import Logger from "../../logger";
+import Logger from "../../Logger";
 import { ParseTTML } from "./parseTTML";
 
 const logger = new Logger("Local Lyrics Manager");

--- a/src/utils/SessionManager/SessionManager.ts
+++ b/src/utils/SessionManager/SessionManager.ts
@@ -1,5 +1,5 @@
 import Platform from "../../components/Global/Platform.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import {
   applyPingConfig,
   BACKOFF_BASE_MS,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,5 +1,5 @@
 import { openDB } from "idb";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const dbLogger = new Logger("Database");
 


### PR DESCRIPTION
## Summary
- `src/utils/Logger.ts` was being imported as `./logger` / `../logger.ts` (lowercase) from 14 files. This only worked by accident because Windows/macOS filesystems are case-insensitive.
- Fixed all 14 import paths to match the real filename. No behavior change.

## Why this matters
- esbuild can treat `logger.ts` and `Logger.ts` as two separate module instances depending on import order this surfaced as a live crash (`Logger_default is not a constructor`) while testing an unrelated change that shifted module evaluation order.
- It breaks outright on case-sensitive filesystems (Linux), so the extension could fail to build/run there today.

## Test plan
- [x] `bun run build` clean, no case-sensitivity warnings (previously ~14 esbuild warnings about this exact mismatch)
- [x] `bun run lint` no new issues
- [x] Verified live in Spotify via Spicetify dev workflow extension loads and runs normally