### PR TITLE
Fix PiP lyrics popup freezing when Spotify is closed to background

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1029,14 +1029,6 @@ async function main() {
 
   runThemeMatcher();
 
-  Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.ESCAPE, async () => {
-    if (IsPIP) return;
-    if (Fullscreen.CinemaViewOpen) {
-      await Fullscreen.Close();
-      Session.GoBack();
-    }
-  });
-
   document.addEventListener("fullscreenchange", async () => {
     if (!document.fullscreenElement && Fullscreen.IsOpen && !Fullscreen.CinemaViewOpen) {
       Fullscreen.CinemaViewOpen = true;
@@ -1045,20 +1037,35 @@ async function main() {
     }
   });
 
-  Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.F11, async () => {
-    if (IsPIP) return;
-    if (Fullscreen.IsOpen) {
-      if (!Fullscreen.CinemaViewOpen) {
-        Fullscreen.CinemaViewOpen = true;
-        await ExitFullscreenElement();
-        PageView.AppendViewControls(true);
-      } else {
-        Fullscreen.CinemaViewOpen = false;
-        await EnterSpicyLyricsFullscreen();
-        PageView.AppendViewControls(true);
-      }
+  // Spicetify.Keyboard isn't guaranteed ready by Platform.OnSpotifyReady (that only
+  // waits on Platform/CosmosAsync), so wait for it explicitly instead of crashing main().
+  Whentil.When(
+    () => Spicetify.Keyboard,
+    () => {
+      Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.ESCAPE, async () => {
+        if (IsPIP) return;
+        if (Fullscreen.CinemaViewOpen) {
+          await Fullscreen.Close();
+          Session.GoBack();
+        }
+      });
+
+      Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.F11, async () => {
+        if (IsPIP) return;
+        if (Fullscreen.IsOpen) {
+          if (!Fullscreen.CinemaViewOpen) {
+            Fullscreen.CinemaViewOpen = true;
+            await ExitFullscreenElement();
+            PageView.AppendViewControls(true);
+          } else {
+            Fullscreen.CinemaViewOpen = false;
+            await EnterSpicyLyricsFullscreen();
+            PageView.AppendViewControls(true);
+          }
+        }
+      });
     }
-  });
+  );
 
   new Spicetify.Menu.Item(
 		"Spicy Lyrics Settings",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,7 +58,7 @@ import "./utils/settings.ts";
 import SLToaster from "./components/ReactComponents/SLToaster.tsx";
 import { openSettingsPanel } from "./utils/settings.ts";
 import { exposeToWindow } from "./utils/expose.ts";
-import Logger from "./utils/logger.ts";
+import Logger from "./utils/Logger.ts";
 import Whentil from "./modules/Whentil.ts";
 import App from "./utils/app.ts";
 import { initSession } from "./utils/SessionManager/index.ts";

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -7,7 +7,7 @@ import { PageContainer } from "../Pages/PageView.ts";
 import Kawarp, { type KawarpOptions } from "@kawarp/core";
 import { BackgroundAnimationController, type AudioAnalysisData } from "./BackgroundAnimationController.ts";
 import { getDynamicAudioAnalysis } from "../../utils/audioAnalysis.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const dynamicBgLogger = new Logger("Dynamic Background");
 

--- a/src/components/Global/Platform.ts
+++ b/src/components/Global/Platform.ts
@@ -17,7 +17,12 @@ const OnSpotifyReady = new Promise<void>((resolve) => {
     SpotifyInternalFetch = Spotify.CosmosAsync;
 
     if (!SpotifyPlatform || !SpotifyInternalFetch) {
-      requestAnimationFrame(() => setTimeout(CheckForServices, 0));
+      // Plain setTimeout, not requestAnimationFrame: this poll has nothing to do with
+      // paint timing, and rAF stops firing entirely once the window is hidden. If the
+      // main window gets backgrounded before Spicetify's globals are ready, an rAF-gated
+      // retry here would wedge the whole extension's boot until the window is foregrounded
+      // again. setTimeout keeps retrying (throttled but not stopped) regardless.
+      setTimeout(CheckForServices, 0);
       return;
     }
 

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -51,6 +51,7 @@ import {
 } from "../Utils/NowBar.ts";
 import TransferElement from "../Utils/TransferElement.ts";
 import { IsPIP, _IsPIP_after, ClosePopupLyrics } from "../Utils/PopupLyrics.ts";
+import { GetActiveWindow } from "../../utils/PipRuntime.ts";
 import { NPVCardOwnsPage, DeRenderNPVCard } from "../Utils/NPVLyrics.ts";
 import { CleanUpIsByCommunity } from "../../utils/Lyrics/Applyer/Credits/ApplyIsByCommunity.tsx";
 import { OpenLyricsDBPanel } from "../../utils/openLyricsDBPanel.tsx";
@@ -329,7 +330,7 @@ async function OpenPage(
 }) */
 
 export const isSizeReadyToBeCompacted = () =>
-  window.matchMedia("(max-width: 70.812rem)").matches;
+  GetActiveWindow().matchMedia("(max-width: 70.812rem)").matches;
 
 export function Compactify(Element: HTMLElement | undefined = undefined) {
   if (!Fullscreen.IsOpen) return;

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -55,7 +55,7 @@ import { NPVCardOwnsPage, DeRenderNPVCard } from "../Utils/NPVLyrics.ts";
 import { CleanUpIsByCommunity } from "../../utils/Lyrics/Applyer/Credits/ApplyIsByCommunity.tsx";
 import { OpenLyricsDBPanel } from "../../utils/openLyricsDBPanel.tsx";
 import { openSettingsPanel } from "../../utils/settings.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 import { triggerRemeasureLV } from "../../utils/Lyrics/LyricsVirtualizer.ts";
 
 const pageLogger = new Logger("Page View");

--- a/src/components/ReactComponents/SLToaster.tsx
+++ b/src/components/ReactComponents/SLToaster.tsx
@@ -2,7 +2,7 @@ import { useStore } from "@nanostores/react";
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
 import { $isGlobalNav } from "../../utils/uiState";
-import Logger from "../../utils/logger";
+import Logger from "../../utils/Logger";
 
 const toasterLogger = new Logger("Toaster");
 

--- a/src/components/Utils/Fullscreen.ts
+++ b/src/components/Utils/Fullscreen.ts
@@ -328,37 +328,42 @@ async function Close(isPip: boolean = false) {
         mainElement.style.removeProperty("display");
       }
 
-      // Apply exit animation and block all interaction for its duration
+      // Apply exit animation and block all interaction for its duration.
+      // Wrapped in try/finally: if anything below throws, pointer-events must
+      // still get released, otherwise the whole main window (title bar
+      // buttons included) is permanently unclickable.
       SpicyPage.classList.add("frame_F_Exit");
       document.body.style.pointerEvents = "none";
 
-      await new Promise(r => setTimeout(r, 650));
+      try {
+        await new Promise(r => setTimeout(r, 650));
 
-      TransferElement(SpicyPage, GetPageRoot() as HTMLElement);
-      SpicyPage.classList.remove("Fullscreen");
+        TransferElement(SpicyPage, GetPageRoot() as HTMLElement);
+        SpicyPage.classList.remove("Fullscreen");
 
-      // Kick off fullscreen exit immediately (no need to wait for animation)
-      const handleFullscreenExit = async () => {
-        await ExitFullscreenElement();
-        setTimeout(() => PageView.AppendViewControls(true), 50);
-      };
-      //setTimeout(() => {
-        handleFullscreenExit()
-      //}, !wasCinemaMode ? 70 : 0);
+        // Kick off fullscreen exit immediately (no need to wait for animation)
+        const handleFullscreenExit = async () => {
+          await ExitFullscreenElement();
+          setTimeout(() => PageView.AppendViewControls(true), 50);
+        };
+        //setTimeout(() => {
+          handleFullscreenExit()
+        //}, !wasCinemaMode ? 70 : 0);
 
-      const NoLyrics = $currentLyricsData.get().includes("NO_LYRICS");
-      if (NoLyrics) {
-        SpicyPage
-          ?.querySelector(".ContentBox .LyricsContainer")
-          ?.classList.remove("Hidden");
-        SpicyPage
-          ?.querySelector<HTMLElement>(".ContentBox")
-          ?.classList.remove("LyricsHidden");
-        DeregisterNowBarBtn();
+        const NoLyrics = $currentLyricsData.get().includes("NO_LYRICS");
+        if (NoLyrics) {
+          SpicyPage
+            ?.querySelector(".ContentBox .LyricsContainer")
+            ?.classList.remove("Hidden");
+          SpicyPage
+            ?.querySelector<HTMLElement>(".ContentBox")
+            ?.classList.remove("LyricsHidden");
+          DeregisterNowBarBtn();
+        }
+      } finally {
+        document.body.style.removeProperty("pointer-events");
+        SpicyPage.classList.remove("frame_F_Exit");
       }
-
-      document.body.style.removeProperty("pointer-events");
-      SpicyPage.classList.remove("frame_F_Exit");
 
       ResetLastLine();
 

--- a/src/components/Utils/NPVLyrics.ts
+++ b/src/components/Utils/NPVLyrics.ts
@@ -15,7 +15,7 @@ import Whentil from "../../modules/Whentil.ts";
 import { $npvLyricsExpanded, $npvLyricsOpen } from "../../utils/uiState.ts";
 import { $currentLyricsData, $hideNpvLyricsWhenUnavailable } from "../../utils/stores.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const cardLogger = new Logger("NPV Lyrics");
 

--- a/src/components/Utils/PopupLyrics.ts
+++ b/src/components/Utils/PopupLyrics.ts
@@ -3,23 +3,42 @@ import Session from "../Global/Session.ts";
 import PageView from "../Pages/PageView.ts";
 import Fullscreen from "./Fullscreen.ts";
 import { NPVCardOwnsPage, DeRenderNPVCard, RequestNPVCardEvaluate } from "./NPVLyrics.ts";
+import {
+  IsPIP,
+  IsPIPOpening,
+  _IsPIP_after,
+  SetIsPIP,
+  SetIsPIPOpening,
+  SetIsPIPAfter,
+  SetPipWindow,
+  GetPipWindow,
+  RequestPipAnimationFrame,
+  CancelPipAnimationFrame,
+  GetActiveDocument,
+  GetActiveWindow,
+} from "../../utils/PipRuntime.ts";
 
-export let IsPIP = false;
-export let _IsPIP_after = false;
-// True for the whole PiP setup flow. The NPV card treats it as "page busy" so
-// it can't re-take the pipeline during the long awaits (requestWindow, style
-// fetches) before IsPIP itself is set.
-export let IsPIPOpening = false;
+// Re-exported for backward compatibility: everything actually lives in PipRuntime.ts
+// (a dependency-free leaf module) so low-level shared modules can use the PiP-aware
+// helpers without pulling in this file's much heavier import chain.
+export {
+  IsPIP,
+  IsPIPOpening,
+  _IsPIP_after,
+  RequestPipAnimationFrame,
+  CancelPipAnimationFrame,
+  GetActiveDocument,
+  GetActiveWindow,
+};
 
-let currentPipWindow = null;
 let pipPageHideHandler: ((event: Event) => void) | null = null;
 
 export const OpenPopupLyrics = async () => {
-  IsPIPOpening = true;
+  SetIsPIPOpening(true);
   try {
     await OpenPopupLyricsFlow();
   } finally {
-    IsPIPOpening = false;
+    SetIsPIPOpening(false);
     // If the flow failed or was cancelled, no page event fires — nudge the
     // card so it can come back.
     RequestNPVCardEvaluate();
@@ -58,13 +77,31 @@ const OpenPopupLyricsFlow = async () => {
 
   // Open a Picture-in-Picture window.
   // @ts-ignore: requestWindow is not yet standard
-  currentPipWindow = await docPiP.requestWindow({
+  const pipWindow = await docPiP.requestWindow({
     disallowReturnToOpener: true,
     preferInitialWindowPlacement: false,
     width: 390,
     height: 379,
   });
 
+  try {
+    await SetUpPipWindow(pipWindow);
+  } catch (e) {
+    // SetUpPipWindow can throw after already publishing PiP state (it needs
+    // IsPIP true before calling PageView.Open/Fullscreen.Open, since those
+    // read it to target the popup). If PageView.Open/Fullscreen.Open then
+    // throw before the pagehide listener is registered, neither
+    // ClosePopupLyrics (gated on IsPIP) nor that listener (never attached)
+    // could clean up, so undo any partial publish here unconditionally,
+    // whether or not it happened.
+    if (!pipWindow.closed) pipWindow.close();
+    SetPipWindow(null);
+    SetIsPIP(false);
+    throw e;
+  }
+};
+
+const SetUpPipWindow = async (pipWindow: Window) => {
   // Copy style sheets over from the initial document
   // so that the player looks the same.
   // Only copy <link> elements with href starting with "https://fonts.spikerko.org" to the PiP window
@@ -91,7 +128,7 @@ const OpenPopupLyricsFlow = async () => {
       if (isUserCss) {
         pipLink.className = link.className;
       }
-      currentPipWindow.document.head.appendChild(pipLink);
+      pipWindow.document.head.appendChild(pipLink);
     }
   });
 
@@ -123,7 +160,7 @@ const OpenPopupLyricsFlow = async () => {
   if (spicyLyricsStyleContent) {
     const newStyleElement = document.createElement("style");
     newStyleElement.textContent = spicyLyricsStyleContent;
-    currentPipWindow.document.head.appendChild(newStyleElement);
+    pipWindow.document.head.appendChild(newStyleElement);
   }
 
   // Additionally, copy the styles element with the id 'spicyLyrics-additionalStyling'
@@ -132,7 +169,7 @@ const OpenPopupLyricsFlow = async () => {
     const newAdditionalStyling = document.createElement("style");
     newAdditionalStyling.id = "spicyLyrics-additionalStyling";
     newAdditionalStyling.textContent = additionalStyling.textContent;
-    currentPipWindow.document.head.appendChild(newAdditionalStyling);
+    pipWindow.document.head.appendChild(newAdditionalStyling);
   }
 
   const additionalStylingElement = document.createElement("style");
@@ -147,44 +184,54 @@ const OpenPopupLyricsFlow = async () => {
     }
   `.replace(/\s+/g, ' ').replace(/;\s*/g, ';').replace(/{\s*/g, '{').replace(/\s*}/g, '}').trim();
 
-  currentPipWindow.document.head.appendChild(additionalStylingElement);
+  pipWindow.document.head.appendChild(additionalStylingElement);
 
-  currentPipWindow.document.body.innerHTML = `<div class="app-drag-region"></div><div class="spicy-pip-wrapper"></div>`;
+  pipWindow.document.body.innerHTML = `<div class="app-drag-region"></div><div class="spicy-pip-wrapper"></div>`;
 
-  const pipWrapper = currentPipWindow.document.body.querySelector(".spicy-pip-wrapper") as HTMLElement;
+  const pipWrapper = pipWindow.document.body.querySelector(".spicy-pip-wrapper") as HTMLElement;
 
-  IsPIP = true;
+  SetPipWindow(pipWindow);
+  SetIsPIP(true);
 
-  PageView.Open(pipWrapper);
+  await PageView.Open(pipWrapper);
 
   Fullscreen.Open(true, false);
 
+  // The window can also be closed by means other than ClosePopupLyrics (e.g.
+  // the user closing the pip window's own native chrome), so we need to tear
+  // down our state either way, otherwise IsPIP stays stuck true and the
+  // popup can never be reopened.
   pipPageHideHandler = () => {
-    // deno-lint-ignore no-window
-    window.location.reload();
+    CleanupPipState();
   };
 
-  currentPipWindow.addEventListener("pagehide", pipPageHideHandler);
+  pipWindow.addEventListener("pagehide", pipPageHideHandler);
 
-  _IsPIP_after = true;
+  SetIsPIPAfter(true);
+};
+
+const CleanupPipState = async () => {
+  SetIsPIPAfter(false);
+
+  await Fullscreen.Close(true);
+  await PageView.Destroy();
+
+  pipPageHideHandler = null;
+  SetPipWindow(null);
+  SetIsPIP(false);
 };
 
 export const ClosePopupLyrics = async () => {
-  if (!IsPIP || !currentPipWindow) return;
-  _IsPIP_after = false;
+  const pipWindow = GetPipWindow();
+  if (!IsPIP || !pipWindow) return;
 
-  await Fullscreen.Close(true)
-  await PageView.Destroy();
-
-  // Remove the event listener before closing the window
+  // Remove the event listener before closing the window so CleanupPipState
+  // doesn't run twice (once here, once from the pagehide it would otherwise trigger)
   if (pipPageHideHandler) {
-    currentPipWindow.removeEventListener("pagehide", pipPageHideHandler);
-    pipPageHideHandler = null;
+    pipWindow.removeEventListener("pagehide", pipPageHideHandler);
   }
 
-  currentPipWindow.close()
+  await CleanupPipState();
 
-  currentPipWindow = null;
-
-  IsPIP = false
+  pipWindow.close();
 }

--- a/src/modules/Scheduler.ts
+++ b/src/modules/Scheduler.ts
@@ -1,3 +1,5 @@
+import { RequestPipAnimationFrame, CancelPipAnimationFrame } from "../utils/PipRuntime.ts";
+
 const SchedulerEnums = {
   timeout: 0,
   interval: 1,
@@ -29,7 +31,7 @@ const Interval =
 const OnPreRender =
   (cb: ScheduledCallback): Scheduled => [
     SchedulerEnums.raf,
-    requestAnimationFrame(cb),
+    RequestPipAnimationFrame(cb),
     { cancelled: false },
   ];
 
@@ -45,7 +47,7 @@ const Cancel = (scheduledItems: Scheduled | Array<Scheduled>) => {
 
     if (type === SchedulerEnums.timeout) window.clearTimeout(id);
     else if (type === SchedulerEnums.interval) window.clearInterval(id);
-    else if (type === SchedulerEnums.raf) cancelAnimationFrame(id);
+    else if (type === SchedulerEnums.raf) CancelPipAnimationFrame(id);
   }
 };
 

--- a/src/utils/API/Query.ts
+++ b/src/utils/API/Query.ts
@@ -1,6 +1,6 @@
 import Defaults from "../../components/Global/Defaults.ts";
 import Session from "../../components/Global/Session.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 export type Query = {
   operation: string;

--- a/src/utils/IntervalManager.ts
+++ b/src/utils/IntervalManager.ts
@@ -1,5 +1,5 @@
 import { Maid } from "../modules/Maid";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const intervalLogger = new Logger("Interval Manager");
 

--- a/src/utils/IntervalManager.ts
+++ b/src/utils/IntervalManager.ts
@@ -1,5 +1,6 @@
 import { Maid } from "../modules/Maid";
 import Logger from "./Logger";
+import { RequestPipAnimationFrame, CancelPipAnimationFrame } from "./PipRuntime.ts";
 
 const intervalLogger = new Logger("Interval Manager");
 
@@ -67,10 +68,10 @@ class IntervalManager {
         this.lastTimestamp = this.duration === 0 ? null : timestamp; // Reset timestamp for immediate execution when duration is infinite
       }
 
-      this.animationFrameId = requestAnimationFrame(loop);
+      this.animationFrameId = RequestPipAnimationFrame(loop);
     };
 
-    this.animationFrameId = requestAnimationFrame(loop);
+    this.animationFrameId = RequestPipAnimationFrame(loop);
 
     // Register cleanup with the Maid
     this.maid.Give(() => this.Stop());
@@ -83,7 +84,7 @@ class IntervalManager {
       this.intervalId = null;
     }
     if (this.animationFrameId !== null) {
-      cancelAnimationFrame(this.animationFrameId);
+      CancelPipAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;
     }
     this.Running = false;

--- a/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
+++ b/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
@@ -1,6 +1,7 @@
 import { QueueForceScroll } from "../../Scrolling/ScrollToActiveLine.ts";
 import { ScrollSimplebar } from "../../Scrolling/Simplebar/ScrollSimplebar.ts";
 import { destroyLyricsVirtualizer } from "../LyricsVirtualizer.ts";
+import { RequestPipAnimationFrame } from "../../PipRuntime.ts";
 
 type LyricsContainerReturnObject = {
   Container: HTMLElement;
@@ -22,7 +23,7 @@ const CreateLyricsContainer = (): LyricsContainerReturnObject => {
   const currentIndex = lastMapIndex;
 
   const Resize = () => {
-    requestAnimationFrame(() => {
+    RequestPipAnimationFrame(() => {
       QueueForceScroll();
       ScrollSimplebar?.recalculate();
     });

--- a/src/utils/Lyrics/LyricsQueueRetry.ts
+++ b/src/utils/Lyrics/LyricsQueueRetry.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import Global from "../../components/Global/Global.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import ApplyLyrics from "./Global/Applyer.ts";
 import fetchLyrics, { ShowQueueLoader } from "./fetchLyrics.ts";
 

--- a/src/utils/Lyrics/LyricsVirtualizer.ts
+++ b/src/utils/Lyrics/LyricsVirtualizer.ts
@@ -5,7 +5,7 @@ import {
   observeElementOffset,
 } from "@tanstack/virtual-core";
 import { Maid } from "../../modules/Maid.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Gap scale factors relative to 1cqw (containerWidth / 100).
 // Gap is baked into each wrapper's padding-bottom so items can have

--- a/src/utils/Lyrics/LyricsVirtualizer.ts
+++ b/src/utils/Lyrics/LyricsVirtualizer.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/virtual-core";
 import { Maid } from "../../modules/Maid.ts";
 import Logger from "../Logger.ts";
+import { RequestPipAnimationFrame, CancelPipAnimationFrame, GetActiveDocument } from "../PipRuntime.ts";
 
 // Gap scale factors relative to 1cqw (containerWidth / 100).
 // Gap is baked into each wrapper's padding-bottom so items can have
@@ -73,6 +74,11 @@ class LyricsVirtualizer {
 
   private _maid: Maid | null = null;
   private _lastVirtualWindowSignature = "";
+
+  // The popup has its own Document, so `document.hidden` here must reflect whichever
+  // one is actually on screen, resolved once per init()/destroy() cycle (PiP state
+  // doesn't change mid-cycle; the page is always torn down and rebuilt around a toggle).
+  private _activeDoc: Document = document;
 
   // Pending verification rAF for scrollToIndex. Programmatic scroll targets a
   // position from measurementsCache, but unmounted items only have _estimateSize,
@@ -183,7 +189,7 @@ class LyricsVirtualizer {
   private _syncScrollRect(): boolean {
     const v = this._virtualizer;
     const el = this._scrollEl;
-    if (!v || !el || document.hidden) return false;
+    if (!v || !el || this._activeDoc.hidden) return false;
     const w = Math.round(el.offsetWidth);
     const h = Math.round(el.offsetHeight);
     if (w === 0 || h === 0) return false; // mirror the zero-width guards elsewhere
@@ -214,7 +220,7 @@ class LyricsVirtualizer {
     // While hidden/minimized/detached the container collapses to 0; measuring
     // then would cache zeros that corrupt the layout on restore. Mirrors the
     // zero-width guards in the resize and width observers.
-    if (document.hidden) return;
+    if (this._activeDoc.hidden) return;
     const clientWidth = el.clientWidth;
     if (clientWidth === 0) return;
     const clientHeight = el.clientHeight;
@@ -305,10 +311,11 @@ class LyricsVirtualizer {
       scrollClientWidth: scrollEl.clientWidth,
     });
     this.destroy();
+    this._activeDoc = GetActiveDocument();
     this._maid = new Maid();
     this._maid.Give(() => {
       if (this._scrollEndTimer !== null) { clearTimeout(this._scrollEndTimer); this._scrollEndTimer = null; }
-      if (this._resizeRAF !== null) { cancelAnimationFrame(this._resizeRAF); this._resizeRAF = null; }
+      if (this._resizeRAF !== null) { CancelPipAnimationFrame(this._resizeRAF); this._resizeRAF = null; }
     });
     this._allElements = lineElements;
     this._wrappers = new Array(lineElements.length).fill(null);
@@ -339,7 +346,7 @@ class LyricsVirtualizer {
         changed = true;
       }
       if (changed && this._resizeRAF === null) {
-        this._resizeRAF = requestAnimationFrame(() => {
+        this._resizeRAF = RequestPipAnimationFrame(() => {
           this._resizeRAF = null;
           if (this._virtualizer === v) {
             virtualizerLogger.debug("ResizeObserver scheduled virtualizer update");
@@ -368,7 +375,7 @@ class LyricsVirtualizer {
         }
       }
       if (changed && this._resizeRAF === null) {
-        this._resizeRAF = requestAnimationFrame(() => {
+        this._resizeRAF = RequestPipAnimationFrame(() => {
           this._resizeRAF = null;
           if (this._virtualizer === v) {
             virtualizerLogger.debug("Class mutation scheduled virtualizer update");
@@ -402,8 +409,8 @@ class LyricsVirtualizer {
     virtualizerLogger.debug("Scroll position reset to top during init");
     this._virtualizer._willUpdate();
 
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
+    RequestPipAnimationFrame(() => {
+      RequestPipAnimationFrame(() => {
         const v = this._virtualizer;
         if (!v || !this._scrollEl) return;
         const settled = this._scrollEl.clientWidth;
@@ -499,9 +506,9 @@ class LyricsVirtualizer {
     // re-triggered _remeasureVisible is a no-op. Force a full remeasure once the page
     // has re-laid out so every re-mounted item gets correct heights.
     const _handleVisibilityRestore = () => {
-      if (document.hidden) return;
+      if (this._activeDoc.hidden) return;
       virtualizerLogger.debug("Visibility restored; forcing remeasure cycle");
-      requestAnimationFrame(() => {
+      RequestPipAnimationFrame(() => {
         const v = this._virtualizer;
         if (!v || !this._scrollEl) return;
         const w = this._scrollEl.clientWidth;
@@ -515,9 +522,9 @@ class LyricsVirtualizer {
         this._onVirtualizerChange(v);
       });
     };
-    document.addEventListener("visibilitychange", _handleVisibilityRestore);
+    this._activeDoc.addEventListener("visibilitychange", _handleVisibilityRestore);
     this._maid!.Give(() =>
-      document.removeEventListener("visibilitychange", _handleVisibilityRestore)
+      this._activeDoc.removeEventListener("visibilitychange", _handleVisibilityRestore)
     );
   }
 
@@ -612,7 +619,7 @@ class LyricsVirtualizer {
         }
         v.measureElement(wrapper);
         if (this._resizeRAF === null) {
-          this._resizeRAF = requestAnimationFrame(() => {
+          this._resizeRAF = RequestPipAnimationFrame(() => {
             this._resizeRAF = null;
             if (this._virtualizer === v) {
               virtualizerLogger.debug("Unmount pass scheduled virtualizer update");
@@ -652,7 +659,7 @@ class LyricsVirtualizer {
       }
     }
     if (didMeasure && this._resizeRAF === null) {
-      this._resizeRAF = requestAnimationFrame(() => {
+      this._resizeRAF = RequestPipAnimationFrame(() => {
         this._resizeRAF = null;
         if (this._virtualizer === v) {
           virtualizerLogger.debug("Mount pass scheduled virtualizer update");
@@ -683,7 +690,7 @@ class LyricsVirtualizer {
     padding: number = 0
   ): void {
     if (this._scrollVerifyRAF !== null) {
-      cancelAnimationFrame(this._scrollVerifyRAF);
+      CancelPipAnimationFrame(this._scrollVerifyRAF);
       this._scrollVerifyRAF = null;
     }
     this._setConverging(true);
@@ -871,7 +878,7 @@ class LyricsVirtualizer {
     }
 
     if (retry < LyricsVirtualizer._MAX_SCROLL_RETRIES) {
-      this._scrollVerifyRAF = requestAnimationFrame(() => {
+      this._scrollVerifyRAF = RequestPipAnimationFrame(() => {
         this._scrollVerifyRAF = null;
         if (this._virtualizer !== v) {
           this._setConverging(false);
@@ -919,7 +926,7 @@ class LyricsVirtualizer {
       hasVirtualizer: Boolean(this._virtualizer),
     });
     if (this._scrollVerifyRAF !== null) {
-      cancelAnimationFrame(this._scrollVerifyRAF);
+      CancelPipAnimationFrame(this._scrollVerifyRAF);
       this._scrollVerifyRAF = null;
     }
     // Reset convergence so the next virtualizer instance doesn't inherit a stale `true`
@@ -955,6 +962,7 @@ class LyricsVirtualizer {
       this._resizeDebounceTimer = null;
     }
     this._onNewElementMounted = null;
+    this._activeDoc = document;
   }
 }
 

--- a/src/utils/Lyrics/ProcessLyrics.ts
+++ b/src/utils/Lyrics/ProcessLyrics.ts
@@ -5,7 +5,7 @@ import langs from "langs";
 import { RetrievePackage } from "../ImportPackage.ts";
 import * as KuromojiAnalyzer from "./KuromojiAnalyzer.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Constants
 const RomajiConverter = new Kuroshiro();

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -5,7 +5,7 @@ import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import PageView, { PageContainer } from "../../components/Pages/PageView.ts";
 import { Query } from "../API/Query.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import { LocalLyricsManager } from "./manager/index.ts";
 import { LyricsQueueRetry } from "./LyricsQueueRetry.ts";
 import { GetExpireStore } from "../../modules/Store.ts";

--- a/src/utils/Lyrics/lyrics.ts
+++ b/src/utils/Lyrics/lyrics.ts
@@ -5,6 +5,7 @@ import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import { Lyrics } from "./Animator/Main.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
 import { Maid } from "../../modules/Maid.ts";
+import { RequestPipAnimationFrame } from "../PipRuntime.ts";
 
 export const ScrollingIntervalTime = Infinity;
 
@@ -222,7 +223,7 @@ const LyricsInterval = () => {
     Lyrics.TimeSetter(progress);
     Lyrics.Animate(progress);
   }
-  requestAnimationFrame(LyricsInterval);
+  RequestPipAnimationFrame(LyricsInterval);
 };
 
 LyricsInterval();

--- a/src/utils/Lyrics/manager/index.ts
+++ b/src/utils/Lyrics/manager/index.ts
@@ -1,5 +1,5 @@
 import { dbPromise, ObjectStores } from "../../db";
-import Logger from "../../logger";
+import Logger from "../../Logger";
 import { ParseTTML } from "./parseTTML";
 
 const logger = new Logger("Local Lyrics Manager");

--- a/src/utils/PipRuntime.ts
+++ b/src/utils/PipRuntime.ts
@@ -1,0 +1,64 @@
+// Zero project imports on purpose. Low-level shared modules (Scheduler, IntervalManager,
+// LyricsVirtualizer, etc.) need PiP-aware requestAnimationFrame/document helpers, but
+// importing them from PopupLyrics.ts would drag in its whole chain (PageView -> Fullscreen
+// -> NPVLyrics -> Session -> ...), which risks circular-import evaluation-order bugs (a
+// module's own top-level `new Logger(...)` running before Logger.ts has finished
+// initializing). Keeping this file dependency-free means anything can import from it
+// without ever risking a cycle.
+export let IsPIP = false;
+// True for the whole PiP setup flow. The NPV card treats it as "page busy" so it can't
+// re-take the pipeline during the long awaits (requestWindow, style fetches) before
+// IsPIP itself is set.
+export let IsPIPOpening = false;
+export let _IsPIP_after = false;
+
+let currentPipWindow: Window | null = null;
+
+export const SetIsPIP = (value: boolean): void => {
+  IsPIP = value;
+};
+
+export const SetIsPIPOpening = (value: boolean): void => {
+  IsPIPOpening = value;
+};
+
+export const SetIsPIPAfter = (value: boolean): void => {
+  _IsPIP_after = value;
+};
+
+export const SetPipWindow = (win: Window | null): void => {
+  currentPipWindow = win;
+};
+
+export const GetPipWindow = (): Window | null => currentPipWindow;
+
+// Document Picture-in-Picture keeps the same JS realm as the opener, but each window has
+// its OWN requestAnimationFrame. The opener's rAF is throttled/frozen by the browser once
+// it's fully hidden (e.g. closed to background, not just minimized), which would silently
+// stall any loop driving the popup's UI. Callers that render into the popup must schedule
+// frames on the pip window itself so they keep running regardless of the opener's visibility.
+export const RequestPipAnimationFrame = (callback: FrameRequestCallback): number => {
+  const win = (IsPIP && currentPipWindow) ? currentPipWindow : window;
+  return win.requestAnimationFrame(callback);
+};
+
+export const CancelPipAnimationFrame = (handle: number): void => {
+  const win = (IsPIP && currentPipWindow) ? currentPipWindow : window;
+  win.cancelAnimationFrame(handle);
+};
+
+// Same reasoning as above but for `document.hidden`/visibilitychange: the popup has its
+// own Document, so checking the opener's `document.hidden` reports the wrong thing entirely
+// (e.g. staying "visible" while the popup is actually the one that went hidden, or bailing
+// on the popup's own layout work because the opener (which isn't even on screen) got
+// backgrounded).
+export const GetActiveDocument = (): Document => {
+  return (IsPIP && currentPipWindow) ? currentPipWindow.document : document;
+};
+
+// Same reasoning again, for anything sizing itself off `window` (matchMedia,
+// innerWidth/innerHeight): the popup is a fixed ~390px window regardless of how wide the
+// main Spotify window happens to be.
+export const GetActiveWindow = (): Window => {
+  return (IsPIP && currentPipWindow) ? currentPipWindow : window;
+};

--- a/src/utils/SessionManager/SessionManager.ts
+++ b/src/utils/SessionManager/SessionManager.ts
@@ -1,5 +1,5 @@
 import Platform from "../../components/Global/Platform.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import {
   applyPingConfig,
   BACKOFF_BASE_MS,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,5 +1,5 @@
 import { openDB } from "idb";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const dbLogger = new Logger("Database");
 


### PR DESCRIPTION
## Problem
The Document Picture-in-Picture (PiP) lyrics popup froze completely (stopped animating, stopped tracking lyrics/progress) whenever the main Spotify window was closed to the system tray/background even though the popup itself stayed open and visible. Simply minimizing the main window worked fine.

## Root cause
Document PiP shares one JS execution context between the opener and the popup, but each window has its OWN `requestAnimationFrame` and `document.hidden`/visibility state. Every place scheduling animation frames or checking visibility for the popup's UI (lyrics scroller, progress virtualization, resize/scroll-into-view, boot checks) was targeting the bare global `window`/`document` (i.e. the opener's) instead of the popup's.
Once the opener is fully backgrounded, the browser throttles/freezes its own rAF loop, silently freezing everything rendered into the popup.

## Fix
- Added `src/utils/PipRuntime.ts`, a small dependency-free module holding the current PiP state (active flag, popup window reference) plus `RequestPipAnimationFrame` / `CancelPipAnimationFrame` / `GetActiveDocument` / `GetActiveWindow` helpers that resolve to the popup's window/document while PiP is active, and to the main window otherwise.
- Migrated every animation-frame/visibility check driving the popup's UI to use these helpers: the lyrics interval loop, the lyrics virtualizer, the render scheduler, the interval manager, and the lyrics container's resize/scroll-into-view logic.
- `PopupLyrics.ts` now sources PiP state/helpers from `PipRuntime.ts` (kept dependency-free to avoid a circular-import chain through `PageView -> Fullscreen -> ...`) and re-exports them for backward compatibility.

Also fixed, found while isolating this bug:
- The popup (a fixed ~390px window) was checking the **main** window's width for its compact-mode/font-size breakpoint instead of its own, sometimes producing oversized or undersized lyrics text.
- `Fullscreen.ts`'s exit animation could leave `pointer-events: none` stuck on `<body>` if interrupted mid-animation, freezing all clicks on the main window; wrapped in `try/finally`.
- `Platform.ts`'s Spicetify-ready boot check used an rAF-gated retry, so backgrounding the window before Spicetify finished initializing could wedge the extension's entire boot sequence; switched to a plain `setTimeout`.
- Removed an unnecessary `window.location.reload()` on popup close/`pagehide` that could interact badly with window lifecycle; replaced with explicit state cleanup.

## Known limitations (not fixed in this PR)
- **Kawarp background doesn't update while backgrounded.** Kawarp's render loop (`@kawarp/core`, third-party) uses the bare global `requestAnimationFrame` internally with no way to inject a custom scheduler, so the animated background keeps its last frame while the main window is backgrounded. We deliberately avoided patching `@kawarp/core` or globally monkeypatching `requestAnimationFrame` an earlier attempt at the latter broke the *main* window's own Now Playing Bar background, since Kawarp runs multiple independent instances internally. Left as a known limitation.
- **Closing Spotify while the popup is still on its very first load.** If the main window is closed to background in the sub-second window right as the popup finishes opening (before its first lyrics fetch/render completes), lyrics, progress bar, and background can end up permanently stuck instead of catching up once repopulated. Observed as under ~1s on a fast machine likely a wider window on slower hardware. Suspected cause is the native player bridge returning transiently inconsistent state during that exact transition, but it wasn't reliably reproducible/fixable within this PR's scope. Documented here as a known issue for follow-up.

## Depends on
#338 (Logger import casing fix) this branch is built on top of it, so its commit will appear in this diff's history until #338 merges into `development`. No changes from #338 are duplicated/re-authored here.

## Testing
- Manual testing in the Spotify desktop client via Spicetify (dev build).
- Verified: popup keeps animating/tracking lyrics and progress correctly after closing the main window to background/tray.
- Verified: main window minimize/close/maximize is unaffected.
- Verified: compact-mode font sizing now reacts to the popup's own width.