### PR TITLE
Update 6.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ src/components/cli-sync
 .claude/settings.local.json
 
 CHANGELOG.md
+
+VOLUME_SLIDER_PLAN.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,35 @@ bun run fmt
 ## Architecture
 
 This is a **Spicetify extension** (not a standalone web app). It runs inside the Spotify desktop client and depends on `window.Spicetify.*` globals being available at runtime. The build tool is `@spicemod/creator` (spicetify-creator), configured in `spice.config.ts`.
+
+## Experiments
+
+User-facing feature flags, shown in Settings → Experiments. Use one whenever a change alters existing behaviour enough that someone might want the old way back.
+
+**Adding one:** append an entry to `EXPERIMENTS` in `src/utils/experiments.ts`. That is the entire registration — the persisted store, the settings row, and the search integration are all derived from it. Do not add anything to `stores.ts`, the settings panel, or the migration list.
+
+```ts
+{
+  id: "myExperiment",            // stable; persisted as "experiment:myExperiment"
+  label: "My Experiment",
+  description: "What it changes, and what turning it off restores.",
+  default: true,
+  pageClass: "Exp_MyExperiment", // optional
+  rebuildsNowBar: true,          // optional
+}
+```
+
+**Implementing one — prefer CSS.** Set `pageClass` and the class is kept in sync on `#SpicyLyricsPage`; write the new look under `#SpicyLyricsPage.Exp_Foo` and the old under `#SpicyLyricsPage:not(.Exp_Foo)`. Toggling is then free and needs no JS.
+
+Only when the *markup* differs (CSS alone can't get you there) read the flag in TS:
+
+```ts
+import { isExperimentEnabled } from "../../utils/experiments.ts";
+const enabled = isExperimentEnabled("myExperiment"); // id is type-checked
+```
+
+Read it once at build time and set `rebuildsNowBar: true` so the fullscreen overlay is torn down and rebuilt when the flag flips — otherwise the toggle won't take effect until the view is reopened. In React, use `useStore($experiment("myExperiment"))`.
+
+**Rules:** `id` is permanent once shipped (it is the storage key). Both states must work — "off" restores the previous behaviour in full, not an approximation. `default: true` for a change you intend to become the norm; `false` for genuinely unfinished work.
+
+`src/utils/experiments.ts` has the full contract in its header comment. `newProgressBarStyling` (the glass progress/volume bars) is the reference implementation — a pure `pageClass` switch, with both skins living side by side in `ContentBox.css`.

--- a/project/config.ts
+++ b/project/config.ts
@@ -1,2 +1,2 @@
 export const ProjectName = "spicy-lyrics";
-export const ProjectVersion = "6.2.4";
+export const ProjectVersion = "6.3.0";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,7 +58,7 @@ import "./utils/settings.ts";
 import SLToaster from "./components/ReactComponents/SLToaster.tsx";
 import { openSettingsPanel } from "./utils/settings.ts";
 import { exposeToWindow } from "./utils/expose.ts";
-import Logger from "./utils/logger.ts";
+import Logger from "./utils/Logger.ts";
 import Whentil from "./modules/Whentil.ts";
 import App from "./utils/app.ts";
 import { initSession } from "./utils/SessionManager/index.ts";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,7 +50,7 @@ import "./css/polyfills/sonner-polyfill.css";
 import "./css/NPVLyrics.css";
 import UpdateDialog from "./components/ReactComponents/UpdateDialog.tsx";
 import { IsPIP, OpenPopupLyrics, ClosePopupLyrics } from "./components/Utils/PopupLyrics.ts";
-import { initNPVLyrics } from "./components/Utils/NPVLyrics.ts";
+import { GetNPVCardElement, initNPVLyrics } from "./components/Utils/NPVLyrics.ts";
 import ReactDOM from "react-dom/client";
 import { PopupModal } from "./components/Modal.ts";
 import { runThemeMatcher } from "./utils/themeMatcher.ts";
@@ -90,6 +90,7 @@ async function main() {
     });
     return () => Global.Event.unListen(id);
   });
+  
 
   Global.SetScope("fullscreen.onclose", (cb: any) => {
     const id = Global.Event.listen("fullscreen:exit", () => {
@@ -521,34 +522,43 @@ async function main() {
       if (!sidebar) return;
 
       nowPlayingBarObserver = new MutationObserver((mutations) => {
+        // Resolved once per callback, not once per record.
+        const card = GetNPVCardElement();
         const shouldReapply = mutations.some((mutation) => {
-          // Ignore mutations inside the NPV lyrics card — its animating
-          // lyrics constantly rewrite style attributes, which would reset
-          // the debounce below forever and starve the npvbg apply. The
-          // card's own insertion/removal still passes (targets its parent).
+          // Cheap type/attribute test first — the ancestor walk below only runs
+          // for records that would otherwise schedule a re-apply.
+          if (mutation.type === "attributes") {
+            const name = mutation.attributeName;
+            if (name !== "src" && name !== "class" && name !== "inert") return false;
+          } else if (mutation.type !== "childList") {
+            return false;
+          }
+          // Ignore mutations inside the NPV lyrics card — the lyrics pipeline
+          // mutates it constantly, which would reset the debounce below forever
+          // and starve the npvbg apply. The card's own insertion/removal still
+          // passes (that mutation targets the card's parent).
           const target = mutation.target;
           const targetElement =
             target instanceof Element ? target : target.parentElement;
-          if (targetElement?.closest("#SpicyLyricsNPVCard")) return false;
-          if (mutation.type === "childList") return true;
-          if (mutation.type !== "attributes") return false;
-          return (
-            mutation.attributeName === "src" ||
-            mutation.attributeName === "style" ||
-            mutation.attributeName === "class" ||
-            mutation.attributeName === "inert"
-          );
+          return !(card && targetElement && card.contains(targetElement));
         });
 
         if (!shouldReapply) return;
         scheduleNowPlayingBarDynamicBackgroundApply();
       });
 
+      // `style` is deliberately absent from the filter: the lyrics animator
+      // rewrites inline styles on every mounted word and letter each frame, and
+      // the card lives inside this observed subtree. Including it made Blink
+      // allocate a MutationRecord per write — hundreds per frame — that this
+      // callback then had to walk and discard. Cover swaps already arrive via
+      // the `playback:songchange` handler, and DOM-driven re-renders via
+      // `childList` / `src` / `class`.
       nowPlayingBarObserver.observe(sidebar, {
         subtree: true,
         childList: true,
         attributes: true,
-        attributeFilter: ["src", "style", "class", "inert"],
+        attributeFilter: ["src", "class", "inert"],
       });
     };
 
@@ -911,6 +921,31 @@ async function main() {
         }
         lastShuffleType = ShuffleType;
       }).Start();
+    }
+
+    {
+      // Volume changes from anywhere (Spotify's own slider, media keys, another
+      // device, our own setVolume) arrive on this native emitter, so there's nothing
+      // to poll. `_events` is an undocumented internal — if Spotify ever drops it the
+      // guard degrades us to "the volume slider doesn't auto-update" rather than
+      // throwing during startup.
+      Whentil.When(
+        () => Spicetify.Platform?.PlaybackAPI,
+        () => {
+          try {
+            Spicetify.Platform.PlaybackAPI?._events?.addListener?.(
+              "volume",
+              (e: { data?: { volume?: number } }) => {
+                const volume = e?.data?.volume;
+                if (typeof volume !== "number") return;
+                Global.Event.evoke("playback:volume", volume);
+              }
+            );
+          } catch (err) {
+            console.error("Spicy Lyrics: couldn't listen for volume changes", err);
+          }
+        }
+      );
     }
 
     {

--- a/src/components/DynamicBG/dynamicBackground.ts
+++ b/src/components/DynamicBG/dynamicBackground.ts
@@ -7,7 +7,7 @@ import { PageContainer } from "../Pages/PageView.ts";
 import Kawarp, { type KawarpOptions } from "@kawarp/core";
 import { BackgroundAnimationController, type AudioAnalysisData } from "./BackgroundAnimationController.ts";
 import { getDynamicAudioAnalysis } from "../../utils/audioAnalysis.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const dynamicBgLogger = new Logger("Dynamic Background");
 

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -17,6 +17,8 @@ type ModalTransitionOptions = {
 	closeHandler?: (() => void) | null;
 	/** Optional class appended to `.sl-modal`. Replaces any previously set modalId class. */
 	modalId?: string | null;
+	/** Optional new header title. Omit to keep the current one. */
+	title?: string | null;
 };
 
 class _HTMLGenericModal extends HTMLElement {
@@ -68,7 +70,7 @@ class _HTMLGenericModal extends HTMLElement {
 	 * Instantly swap modal content without hiding/re-animating.
 	 * Use for modal-to-modal transitions where the frame should stay visible.
 	 */
-	transition({ content, onClose = null, closeHandler = null, modalId = null }: ModalTransitionOptions): void {
+	transition({ content, onClose = null, closeHandler = null, modalId = null, title = null }: ModalTransitionOptions): void {
 		if (typeof this._onClose === "function") {
 			this._onClose();
 		}
@@ -76,6 +78,10 @@ class _HTMLGenericModal extends HTMLElement {
 		const closeButton = this.querySelector(".sl-modal-close-btn");
 		if (closeButton) {
 			(closeButton as HTMLButtonElement).onclick = closeHandler ?? this.hide.bind(this);
+		}
+		if (typeof title === "string") {
+			const titleEl = this.querySelector(".sl-modal-title");
+			if (titleEl) titleEl.textContent = title;
 		}
 		this._applyModalId(modalId);
 		const main = this.querySelector("main");

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -21,8 +21,10 @@ import { ScrollSimplebar } from "../../utils/Scrolling/Simplebar/ScrollSimplebar
 import ApplyDynamicBackground, { KawarpMap } from "../DynamicBG/dynamicBackground.ts";
 import {
   $currentLyricsData,
+  $lineHoverBackground,
   $lyricsContainerExists,
   $minimalLyricsMode,
+  $showVolumeSlider,
   $simpleLyricsMode,
   $skipSpicyFont,
   $ttmlMakerMode,
@@ -56,6 +58,7 @@ import { CleanUpIsByCommunity } from "../../utils/Lyrics/Applyer/Credits/ApplyIs
 import { OpenLyricsDBPanel } from "../../utils/openLyricsDBPanel.tsx";
 import { openSettingsPanel } from "../../utils/settings.ts";
 import Logger from "../../utils/Logger.ts";
+import { ApplyExperimentClasses, onExperimentChange } from "../../utils/experiments.ts";
 import { triggerRemeasureLV } from "../../utils/Lyrics/LyricsVirtualizer.ts";
 
 const pageLogger = new Logger("Page View");
@@ -229,6 +232,18 @@ async function OpenPage(
   if ($minimalLyricsMode.get()) {
     elem.classList.add("MinimalLyricsMode");
   }
+
+  if (!$lineHoverBackground.get()) {
+    elem.classList.add("NoLineHoverBackground");
+  }
+
+  // Gates the raised .PlaybackControls / tightened .Heart offsets that make room for
+  // the volume band — without it, turning the setting off would leave a gap.
+  if ($showVolumeSlider.get()) {
+    elem.classList.add("ShowVolumeSlider");
+  }
+
+  ApplyExperimentClasses(elem);
 
   const contentBox = elem.querySelector<HTMLElement>(
     ".ContentBox"
@@ -746,9 +761,28 @@ $minimalLyricsMode.listen((v) => {
   if (uri) fetchLyrics(uri).then(ApplyLyrics);
 });
 
+// Purely a CSS toggle — no need to re-render the lyrics like the modes above do.
+$lineHoverBackground.listen((v) => {
+  if (!PageContainer) return;
+  PageContainer.classList.toggle("NoLineHoverBackground", !v);
+});
+
 $skipSpicyFont.listen((v) => {
   if (!PageContainer) return;
   PageContainer.classList.toggle("UseSpicyFont", !v);
+});
+
+// Purely a CSS gate — NowBar.ts handles rebuilding the band itself.
+$showVolumeSlider.listen((v) => {
+  if (!PageContainer) return;
+  PageContainer.classList.toggle("ShowVolumeSlider", v);
+});
+
+// Experiments own their CSS hook here; NowBar.ts handles the rebuild for the ones
+// that need one. Adding an experiment requires no change to this file.
+onExperimentChange(() => {
+  if (!PageContainer) return;
+  ApplyExperimentClasses(PageContainer);
 });
 
 $viewControlsPosition.listen((v) => {

--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -55,7 +55,7 @@ import { NPVCardOwnsPage, DeRenderNPVCard } from "../Utils/NPVLyrics.ts";
 import { CleanUpIsByCommunity } from "../../utils/Lyrics/Applyer/Credits/ApplyIsByCommunity.tsx";
 import { OpenLyricsDBPanel } from "../../utils/openLyricsDBPanel.tsx";
 import { openSettingsPanel } from "../../utils/settings.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 import { triggerRemeasureLV } from "../../utils/Lyrics/LyricsVirtualizer.ts";
 
 const pageLogger = new Logger("Page View");

--- a/src/components/ReactComponents/SLToaster.tsx
+++ b/src/components/ReactComponents/SLToaster.tsx
@@ -2,7 +2,7 @@ import { useStore } from "@nanostores/react";
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
 import { $isGlobalNav } from "../../utils/uiState";
-import Logger from "../../utils/logger";
+import Logger from "../../utils/Logger";
 
 const toasterLogger = new Logger("Toaster");
 

--- a/src/components/ReactComponents/SettingsPanel/ExperimentsPanel.tsx
+++ b/src/components/ReactComponents/SettingsPanel/ExperimentsPanel.tsx
@@ -1,0 +1,58 @@
+import { useStore } from "@nanostores/react";
+import {
+  $experiment,
+  EXPERIMENTS,
+  type RegisteredExperiment,
+} from "../../../utils/experiments.ts";
+import { Row, Toggle } from "./components.tsx";
+
+/**
+ * The Experiments sub-panel. Renders straight off the EXPERIMENTS registry, so a
+ * new experiment shows up here the moment it's added to `utils/experiments.ts`.
+ */
+export default function ExperimentsPanel({ onBack }: { onBack: () => void }) {
+  return (
+    <div style={{ padding: "8px 0" }} className="slm w-40">
+      <div className="sl-sp-subheader">
+        <button className="sl-sp-back-btn" onClick={onBack} aria-label="Back to Settings">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8.5 2.5L4 7l4.5 4.5"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Settings
+        </button>
+      </div>
+
+      <p className="sl-sp-experiments-note">
+        These features are still being shaped. Toggle one off if you prefer how things worked
+        before — everything here is safe to switch at any time.
+      </p>
+
+      {EXPERIMENTS.map((exp) => (
+        <ExperimentRow key={exp.id} experiment={exp} />
+      ))}
+    </div>
+  );
+}
+
+function ExperimentRow({ experiment }: { experiment: RegisteredExperiment }) {
+  const store = $experiment(experiment.id);
+  const enabled = useStore(store);
+
+  return (
+    <Row label={experiment.label} description={experiment.description}>
+      <Toggle checked={enabled} onChange={(v) => store.set(v)} />
+    </Row>
+  );
+}

--- a/src/components/ReactComponents/SettingsPanel/ExperimentsSection.tsx
+++ b/src/components/ReactComponents/SettingsPanel/ExperimentsSection.tsx
@@ -1,0 +1,40 @@
+import { EXPERIMENTS } from "../../../utils/experiments.ts";
+import { matches, Row, SectionTitle } from "./components.tsx";
+
+const SECTION_NAME = "Experiments";
+
+const LABEL = "Experiments";
+const DESCRIPTION =
+  "Try out in-progress features, and switch back if you prefer the old behaviour.";
+
+interface Props {
+  query: string;
+  sectionFilter: string;
+  onOpen: () => void;
+}
+
+export default function ExperimentsSection({ query, sectionFilter, onOpen }: Props) {
+  if (sectionFilter !== "All" && sectionFilter !== SECTION_NAME) return null;
+
+  // Searching for an experiment by its own name should surface this row too,
+  // otherwise the flags would be invisible to the search box.
+  const hit =
+    matches(query, LABEL, DESCRIPTION) ||
+    EXPERIMENTS.some((exp) => matches(query, exp.label, exp.description));
+
+  if (!hit) return null;
+
+  const count = EXPERIMENTS.length;
+
+  return (
+    <>
+      <SectionTitle>Experiments</SectionTitle>
+
+      <Row label={LABEL} description={DESCRIPTION}>
+        <button className="sl-sp-btn" onClick={onOpen} disabled={count === 0}>
+          {count > 0 ? `Open (${count})` : "None available"}
+        </button>
+      </Row>
+    </>
+  );
+}

--- a/src/components/ReactComponents/SettingsPanel/InterfaceSection.tsx
+++ b/src/components/ReactComponents/SettingsPanel/InterfaceSection.tsx
@@ -1,8 +1,10 @@
 import { useStore } from "@nanostores/react";
 import {
+  $disableNpvLyrics,
   $hideNpvLyricsWhenUnavailable,
   $lockedMediaBox,
   $popupLyricsAllowed,
+  $showVolumeSlider,
   $timelineOutsideMediaContent,
   $viewControlsPosition,
 } from "../../../utils/stores.ts";
@@ -22,7 +24,9 @@ export default function InterfaceSection({ query, sectionFilter }: Props) {
   const popupLyricsAllowed = useStore($popupLyricsAllowed);
   const viewControlsPosition = useStore($viewControlsPosition);
   const timelineOutsideMediaContent = useStore($timelineOutsideMediaContent);
+  const showVolumeSlider = useStore($showVolumeSlider);
   const hideNpvLyricsWhenUnavailable = useStore($hideNpvLyricsWhenUnavailable);
+  const disableNpvLyrics = useStore($disableNpvLyrics);
   const isGlobalNav = useStore($isGlobalNav);
 
   if (sectionFilter !== "All" && sectionFilter !== SECTION_NAME) return null;
@@ -32,8 +36,10 @@ export default function InterfaceSection({ query, sectionFilter }: Props) {
   const r4 = matches(query, "Lyrics Controls Position", "Where the lyrics view controls (play, scroll, etc.) appear.");
   const r5 = matches(query, "Timeline Outside Media Box", "Display the playback timeline outside the media box, in the NowBar header. Stays inside the media box in Compact Mode or PIP.");
   const r6 = matches(query, "Hide NPV Lyrics When No Lyrics Are Available", "Remove the lyrics card from the Now Playing sidebar while the current song has no lyrics, instead of showing a notice. It comes back on the next song that has them.");
+  const r7 = matches(query, "Disable NPV Lyrics", "Never show the lyrics card in the Now Playing sidebar.");
+  const r8 = matches(query, "Volume Slider", "Show a volume control on the album artwork in Fullscreen, Cinema View and Popup Lyrics.");
 
-  if (!r2 && !r3 && !r4 && !r5 && !r6) return null;
+  if (!r2 && !r3 && !r4 && !r5 && !r6 && !r7 && !r8) return null;
 
   return (
     <>
@@ -84,10 +90,30 @@ export default function InterfaceSection({ query, sectionFilter }: Props) {
         </Row>
       )}
 
+      {r8 && (
+        <Row
+          label="Volume Slider"
+          description="Show a volume control on the album artwork in Fullscreen, Cinema View and Popup Lyrics."
+        >
+          <Toggle checked={showVolumeSlider} onChange={(v) => $showVolumeSlider.set(v)} />
+        </Row>
+      )}
+
+      {r7 && (
+        <Row
+          label="Disable NPV Lyrics"
+          description="Never show the lyrics card in the Now Playing sidebar."
+        >
+          <Toggle checked={disableNpvLyrics} onChange={(v) => $disableNpvLyrics.set(v)} />
+        </Row>
+      )}
+
       {r6 && (
         <Row
           label="Hide NPV Lyrics When No Lyrics Are Available"
           description="Remove the lyrics card from the Now Playing sidebar while the current song has no lyrics, instead of showing a notice. It comes back on the next song that has them."
+          disabled={disableNpvLyrics}
+          disabledReason="The NPV lyrics card is disabled"
         >
           <Toggle
             checked={hideNpvLyricsWhenUnavailable}

--- a/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
+++ b/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "@nanostores/react";
 import React from "react";
 import {
+  $lineHoverBackground,
   $minimalLyricsMode,
   $simpleLyricsMode,
   $simpleLyricsModeRenderingType,
@@ -21,6 +22,7 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
   const simpleLyricsModeRenderingType = useStore($simpleLyricsModeRenderingType);
   const minimalLyricsMode = useStore($minimalLyricsMode);
   const allowScrollUp = useStore($allowScrollUp);
+  const lineHoverBackground = useStore($lineHoverBackground);
 
   if (sectionFilter !== "All" && sectionFilter !== SECTION_NAME) return null;
 
@@ -28,8 +30,9 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
   const r2 = matches(query, "Simple Mode: Text Animation Style", "How lyrics text transitions are rendered in Simple Lyrics Mode.");
   const r3 = matches(query, "Minimal Lyrics Mode", "Hides sung lyrics lines in Fullscreen and Cinema Mode");
   const r4 = matches(query, "Allow Scrolling Up", "Allow lyrics to scroll back up when the active line is above the last one");
+  const r5 = matches(query, "Line Hover Background", "Shows a highlight box behind a lyrics line when you hover over it");
 
-  if (!r1 && !r2 && !r3 && !r4) return null;
+  if (!r1 && !r2 && !r3 && !r4 && !r5) return null;
 
   return (
     <>
@@ -74,6 +77,16 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
           <Toggle checked={allowScrollUp} onChange={(v) => $allowScrollUp.set(v)} />
         </Row>
       )}
+
+      {r5 && (
+        <Row
+          label="Line Hover Background"
+          description="Shows a highlight box behind a lyrics line when you hover over it"
+        >
+          <Toggle checked={lineHoverBackground} onChange={(v) => $lineHoverBackground.set(v)} />
+        </Row>
+      )}
+ 
     </>
   );
 }

--- a/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
+++ b/src/components/ReactComponents/SettingsPanel/LyricsSection.tsx
@@ -4,6 +4,7 @@ import {
   $minimalLyricsMode,
   $simpleLyricsMode,
   $simpleLyricsModeRenderingType,
+  $allowScrollUp
 } from "../../../utils/stores.ts";
 import { matches, Row, Select, SectionTitle, Toggle } from "./components.tsx";
 
@@ -19,14 +20,16 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
   const simpleLyricsMode = useStore($simpleLyricsMode);
   const simpleLyricsModeRenderingType = useStore($simpleLyricsModeRenderingType);
   const minimalLyricsMode = useStore($minimalLyricsMode);
+  const allowScrollUp = useStore($allowScrollUp);
 
   if (sectionFilter !== "All" && sectionFilter !== SECTION_NAME) return null;
 
   const r1 = matches(query, "Simple Lyrics Mode", "Remove extra visual effects from lyrics");
   const r2 = matches(query, "Simple Mode: Text Animation Style", "How lyrics text transitions are rendered in Simple Lyrics Mode.");
   const r3 = matches(query, "Minimal Lyrics Mode", "Hides sung lyrics lines in Fullscreen and Cinema Mode");
+  const r4 = matches(query, "Allow Scrolling Up", "Allow lyrics to scroll back up when the active line is above the last one");
 
-  if (!r1 && !r2 && !r3) return null;
+  if (!r1 && !r2 && !r3 && !r4) return null;
 
   return (
     <>
@@ -60,6 +63,15 @@ export default function LyricsSection({ query, sectionFilter }: Props) {
           description="Hides sung lyrics lines in Fullscreen and Cinema Mode"
         >
           <Toggle checked={minimalLyricsMode} onChange={(v) => $minimalLyricsMode.set(v)} />
+        </Row>
+      )}
+
+      {r4 && (
+        <Row
+          label="Allow Scrolling Up"
+          description="Allow lyrics to scroll back up when the active line is above the last one"
+        >
+          <Toggle checked={allowScrollUp} onChange={(v) => $allowScrollUp.set(v)} />
         </Row>
       )}
     </>

--- a/src/components/ReactComponents/SettingsPanel/index.tsx
+++ b/src/components/ReactComponents/SettingsPanel/index.tsx
@@ -3,6 +3,7 @@ import AppearanceSection from "./AppearanceSection.tsx";
 import BackgroundSection from "./BackgroundSection.tsx";
 import CacheSection from "./CacheSection.tsx";
 import DeveloperSection from "./DeveloperSection.tsx";
+import ExperimentsSection from "./ExperimentsSection.tsx";
 import InterfaceSection from "./InterfaceSection.tsx";
 import LyricsSection from "./LyricsSection.tsx";
 import PlaybackSection from "./PlaybackSection.tsx";
@@ -14,11 +15,12 @@ const SECTIONS = [
   "Playback",
   "Appearance",
   "Interface",
+  "Experiments",
   "Developer",
   "Cache",
 ];
 
-export default function SettingsPanel() {
+export default function SettingsPanel({ onOpenExperiments }: { onOpenExperiments: () => void }) {
   const [query, setQuery] = useState("");
   const [sectionFilter, setSectionFilter] = useState("All");
 
@@ -34,6 +36,11 @@ export default function SettingsPanel() {
       <PlaybackSection query={query} sectionFilter={sectionFilter} />
       <AppearanceSection query={query} sectionFilter={sectionFilter} />
       <InterfaceSection query={query} sectionFilter={sectionFilter} />
+      <ExperimentsSection
+        query={query}
+        sectionFilter={sectionFilter}
+        onOpen={onOpenExperiments}
+      />
       <DeveloperSection query={query} sectionFilter={sectionFilter} />
       <CacheSection query={query} sectionFilter={sectionFilter} />
     </div>

--- a/src/components/Styling/Icons.ts
+++ b/src/components/Styling/Icons.ts
@@ -64,6 +64,17 @@ export const Icons = {
 			<path d="M 18.885 6.353 C 19.52 6.353 19.888 6.008 19.888 5.318 L 19.888 1.236 C 19.888 0.511 19.409 0.022 18.696 0.022 C 18.105 0.022 17.758 0.21 17.302 0.556 L 16.176 1.437 C 15.907 1.639 15.819 1.839 15.819 2.073 C 15.819 2.418 16.074 2.697 16.488 2.697 C 16.666 2.697 16.81 2.641 16.956 2.529 L 17.781 1.839 L 17.859 1.839 L 17.859 5.318 C 17.859 6.008 18.227 6.353 18.885 6.353 L 18.885 6.353 Z M 1.147 8.986 C 1.791 9.003 2.319 8.48 2.306 7.836 L 2.306 7.234 C 2.306 5.886 3.254 4.982 4.703 4.982 L 9.274 4.982 L 9.274 6.811 C 9.274 7.358 9.62 7.703 10.178 7.703 C 10.42 7.703 10.653 7.616 10.836 7.457 L 14.302 4.548 C 14.727 4.191 14.727 3.621 14.302 3.265 L 10.837 0.333 C 10.655 0.175 10.421 0.087 10.179 0.088 C 9.622 0.088 9.275 0.434 9.275 0.981 L 9.275 2.719 L 4.873 2.719 C 1.895 2.719 0 4.403 0 7.034 L 0 7.836 C 0 8.494 0.502 8.984 1.148 8.984 L 1.147 8.986 Z M 7.68 16.978 C 8.226 16.978 8.572 16.633 8.572 16.086 L 8.572 14.336 L 15.127 14.336 C 18.115 14.336 20 12.652 20 10.021 L 20 9.219 C 20.013 8.58 19.491 8.058 18.851 8.071 C 18.21 8.054 17.686 8.578 17.703 9.219 L 17.703 9.821 C 17.703 11.169 16.744 12.073 15.295 12.073 L 8.572 12.073 L 8.572 10.256 C 8.572 9.709 8.226 9.364 7.68 9.364 C 7.435 9.364 7.198 9.45 7.011 9.609 L 3.555 12.53 C 3.12 12.875 3.132 13.443 3.555 13.8 L 7.011 16.744 C 7.201 16.895 7.437 16.977 7.68 16.978 L 7.68 16.978 Z" fill-rule="nonzero" transform="matrix(1, 0, 0, 1, 0, -8.881784197001252e-16)"/>
 		</svg>
 	`,
+  // One SVG for every volume state — the waves and the mute cross are toggled via
+  // opacity by the .Muted / .Low / .High classes on .VolumeControl, so the markup
+  // never has to be swapped while the level changes.
+  Volume: `
+		<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="Volume">
+			<path id="SpicyLyrics_VolumeSpeaker" d="M11 4.5 6.5 8.5H3.5c-.83 0-1.5.67-1.5 1.5v4c0 .83.67 1.5 1.5 1.5h3l4.5 4c.65.58 1.5.1 1.5-.68V5.18c0-.78-.85-1.26-1.5-.68z"/>
+			<path id="SpicyLyrics_VolumeWaveLow" d="M15.2 9.6a1 1 0 0 1 1.4 0 3.4 3.4 0 0 1 0 4.8 1 1 0 1 1-1.4-1.4 1.4 1.4 0 0 0 0-2 1 1 0 0 1 0-1.4z"/>
+			<path id="SpicyLyrics_VolumeWaveHigh" d="M17.9 6.9a1 1 0 0 1 1.4 0 7.2 7.2 0 0 1 0 10.2 1 1 0 1 1-1.4-1.4 5.2 5.2 0 0 0 0-7.4 1 1 0 0 1 0-1.4z"/>
+			<path id="SpicyLyrics_VolumeMute" d="M15.3 8.8a1 1 0 0 1 1.4 0l1.8 1.8 1.8-1.8a1 1 0 1 1 1.4 1.4L19.9 12l1.8 1.8a1 1 0 0 1-1.4 1.4l-1.8-1.8-1.8 1.8a1 1 0 0 1-1.4-1.4l1.8-1.8-1.8-1.8a1 1 0 0 1 0-1.4z"/>
+		</svg>
+	`,
   CinemaView: `<svg class="NoFill" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="13" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><path d="m10.5 8.5 3.5 2-3.5 2z" fill="currentColor"/></svg>`,
   Collapse: `<svg class="NoFill" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 15 6-6 6 6"/></svg>`,
   Uncollapse: `<svg class="NoFill" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>`,

--- a/src/components/Utils/Fullscreen.ts
+++ b/src/components/Utils/Fullscreen.ts
@@ -82,7 +82,22 @@ const RunMediaBoxAnimation = () => {
   ControlsMaid.Give(Scheduler.OnPreRender(RunMediaBoxAnimation), "MediaBoxAnimation");
 };
 
+// While a slider handle is being dragged the pointer regularly leaves the MediaBox,
+// and `MediaBox_MouseOut` fires unconditionally — without this latch the controls
+// would fade out from under the cursor mid-drag.
+let controlsDragLock = false;
+
+export const SetControlsDragLock = (locked: boolean) => {
+  if (controlsDragLock === locked) return;
+  controlsDragLock = locked;
+  // Re-evaluate once the drag is over so the controls settle into whatever the
+  // hover state became while we were ignoring it.
+  if (!locked) ToggleControls(true);
+};
+
 const ToggleControls = (force: boolean = false) => {
+  if (controlsDragLock) return;
+
   const now = performance.now();
 
   const getControlsOpacityGoal = () => {
@@ -191,6 +206,7 @@ function CleanupMediaBox() {
   visualsApplied = false;
   mediaBoxHover = false;
   pageHover = false;
+  controlsDragLock = false;
 }
 
 function Open(skipDocumentFullscreen: boolean = false, moveElement: boolean = true) {

--- a/src/components/Utils/NPVLyrics.ts
+++ b/src/components/Utils/NPVLyrics.ts
@@ -13,7 +13,11 @@ import { Icons } from "../Styling/Icons.ts";
 import { Maid } from "../../modules/Maid.ts";
 import Whentil from "../../modules/Whentil.ts";
 import { $npvLyricsExpanded, $npvLyricsOpen } from "../../utils/uiState.ts";
-import { $currentLyricsData, $hideNpvLyricsWhenUnavailable } from "../../utils/stores.ts";
+import {
+  $currentLyricsData,
+  $disableNpvLyrics,
+  $hideNpvLyricsWhenUnavailable,
+} from "../../utils/stores.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
 import Logger from "../../utils/Logger.ts";
 
@@ -31,6 +35,8 @@ const watcherMaid = new Maid();
 let evaluateTimer: ReturnType<typeof setTimeout> | null = null;
 let evaluating = false;
 let evaluateAgain = false;
+// Non-null while the card's open/close morph is running; see holdEvaluateUntilSettled.
+let stateAnimation: Animation | null = null;
 
 const getNPV = (): HTMLElement | null =>
   document.querySelector<HTMLElement>(
@@ -42,6 +48,17 @@ const getNPV = (): HTMLElement | null =>
 
 export function NPVCardOwnsPage(): boolean {
   return cardOwnsPage;
+}
+
+/**
+ * The injected card element, or null when no card is rendered.
+ *
+ * Exposed so the sidebar-wide observers elsewhere can skip mutations that
+ * originate inside the card (the lyrics pipeline mutates it constantly) with a
+ * plain `contains()` parent-pointer walk instead of re-matching a selector.
+ */
+export function GetNPVCardElement(): HTMLElement | null {
+  return cardEl;
 }
 
 export async function DeRenderNPVCard(): Promise<void> {
@@ -70,6 +87,7 @@ function hiddenForMissingLyrics(): boolean {
 }
 
 function desiredState(): CardState {
+  if ($disableNpvLyrics.get()) return "DORMANT";
   const npv = getNPV();
   // closest("[inert]") covers the whole .Root__right-sidebar <-> aside chain
   if (!npv || !npv.isConnected || npv.closest("[inert]")) return "DORMANT";
@@ -174,13 +192,17 @@ function animateStateChange(mutate: () => void): void {
 
   // Stretch the card box from its old size to its new one (overflow: hidden
   // clips the body while it grows/shrinks).
-  card.animate(
+  const morph = card.animate(
     [
       { width: `${firstCard.width}px`, height: `${firstCard.height}px` },
       { width: `${lastCard.width}px`, height: `${lastCard.height}px` },
     ],
     { duration: STATE_ANIM_MS, easing: STATE_ANIM_EASE }
   );
+  // Only the expanded body flexes with the animated card height (`flex: 1 1 auto`);
+  // the compact one is pinned and merely clipped, so it can render straight away
+  // rather than waiting out the morph.
+  if (card.classList.contains("Expanded")) holdEvaluateUntilSettled(morph);
 
   // Glide each control from its old spot (right cluster <-> centered).
   buttons.forEach((button, i) => {
@@ -357,10 +379,41 @@ async function evaluate(): Promise<void> {
 // PageView.Open) finish before conditions are re-read.
 function scheduleEvaluate(): void {
   if (evaluateTimer !== null) return;
+  // A morph is in flight — its settle handler re-schedules us. See
+  // holdEvaluateUntilSettled.
+  if (stateAnimation !== null) return;
   evaluateTimer = setTimeout(() => {
     evaluateTimer = null;
     void evaluate();
   }, 100);
+}
+
+/**
+ * Park pending evaluates until the card's size morph finishes.
+ *
+ * reconcile() runs the synchronous, DOM-heavy PageView.Open/Destroy. The 100ms
+ * debounce used to drop that squarely inside the 350ms morph — and because the
+ * card body is a `container-type: size` container whose type scale is cqw-derived,
+ * every animation frame re-resolved the lyrics' font sizes, relaid out every
+ * mounted line, and kicked the virtualizer's per-wrapper ResizeObserver into
+ * another measure/mount cycle. Letting the box settle first means the lyrics are
+ * built and measured once, against final dimensions.
+ */
+function holdEvaluateUntilSettled(animation: Animation): void {
+  if (evaluateTimer !== null) {
+    clearTimeout(evaluateTimer);
+    evaluateTimer = null;
+  }
+  stateAnimation = animation;
+  const settle = () => {
+    // A newer morph took over; it owns the re-schedule now.
+    if (stateAnimation !== animation) return;
+    stateAnimation = null;
+    scheduleEvaluate();
+  };
+  // finished rejects when the animation is cancelled (card torn down mid-morph);
+  // settle either way so we can never wedge with a stale hold.
+  animation.finished.then(settle, settle);
 }
 
 let observedSidebar: Element | null = null;
@@ -439,6 +492,8 @@ export function initNPVLyrics(): void {
   // un-hide trigger.
   watcherMaid.Give($currentLyricsData.listen(() => scheduleEvaluate()));
   watcherMaid.Give($hideNpvLyricsWhenUnavailable.listen(() => scheduleEvaluate()));
+  // Turning the card off tears it down live; turning it back on re-injects it.
+  watcherMaid.Give($disableNpvLyrics.listen(() => scheduleEvaluate()));
 
   Whentil.When(
     () =>

--- a/src/components/Utils/NPVLyrics.ts
+++ b/src/components/Utils/NPVLyrics.ts
@@ -15,7 +15,7 @@ import Whentil from "../../modules/Whentil.ts";
 import { $npvLyricsExpanded, $npvLyricsOpen } from "../../utils/uiState.ts";
 import { $currentLyricsData, $hideNpvLyricsWhenUnavailable } from "../../utils/stores.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
-import Logger from "../../utils/logger.ts";
+import Logger from "../../utils/Logger.ts";
 
 const cardLogger = new Logger("NPV Lyrics");
 

--- a/src/components/Utils/NowBar.ts
+++ b/src/components/Utils/NowBar.ts
@@ -2,14 +2,15 @@ import BlobURLMaker from "../../utils/BlobURLMaker.ts";
 import { GetCurrentLyricsContainerInstance } from "../../utils/Lyrics/Applyer/CreateLyricsContainer.ts";
 import { SongProgressBar } from "./../../utils/Lyrics/SongProgressBar.ts";
 import { QueueForceScroll, ResetLastLine } from "../../utils/Scrolling/ScrollToActiveLine.ts";
-import { $timelineOutsideMediaContent } from "../../utils/stores.ts";
+import { $showVolumeSlider, $timelineOutsideMediaContent } from "../../utils/stores.ts";
+import { onExperimentChange } from "../../utils/experiments.ts";
 import { $isNowBarOpen, $nowBarSide } from "../../utils/uiState.ts";
 import Global from "../Global/Global.ts";
 import Session from "../Global/Session.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
 import PageView, { PageContainer } from "../Pages/PageView.ts";
 import { Icons } from "../Styling/Icons.ts";
-import Fullscreen, { CleanupMediaBox } from "./Fullscreen.ts";
+import Fullscreen, { CleanupMediaBox, SetControlsDragLock } from "./Fullscreen.ts";
 import { IsPIP } from "./PopupLyrics.ts";
 import { IsCompactMode } from "./CompactMode.ts";
 import { Maid } from "../../modules/Maid.ts";
@@ -29,7 +30,17 @@ interface SongProgressBarInstance {
   GetElement: () => HTMLElement;
 }
 
+interface VolumeControlInstance {
+  Apply: () => void;
+  CleanUp: () => void;
+  GetElement: () => HTMLElement;
+  /** Render an externally-originated level without echoing it back to Spotify. */
+  SetVolume: (volume: number) => void;
+  IsDragging: () => boolean;
+}
+
 let ActivePlaybackControlsInstance: PlaybackControlsInstance | null = null;
+let ActiveVolumeControlInstance: VolumeControlInstance | null = null;
 const ActiveSongProgressBarInstance_Map = new Map<string, any>();
 let ActiveSetupSongProgressBarInstance: SongProgressBarInstance | null = null;
 
@@ -470,7 +481,12 @@ function OpenNowBar(skipSaving: boolean = false) {
 
         const handleDragStart = (event: MouseEvent | TouchEvent) => {
           isDragging = true;
+          // .Dragging keeps the bar thickened and turns off the fill's eased glide
+          // so it tracks the pointer 1:1.
+          SliderBar.classList.add("Dragging");
           document.body.style.userSelect = "none"; // Prevent text selection during drag
+          // Keep the overlay visible if the pointer leaves the artwork mid-drag
+          SetControlsDragLock(true);
 
           // Add the event listeners for drag movement and end
           document.addEventListener("mousemove", handleDragMove);
@@ -529,6 +545,7 @@ function OpenNowBar(skipSaving: boolean = false) {
         const handleDragEnd = (event: MouseEvent | TouchEvent) => {
           if (!isDragging) return;
           isDragging = false;
+          SliderBar.classList.remove("Dragging");
           document.body.style.userSelect = ""; // Restore text selection
 
           // Remove the event listeners
@@ -567,6 +584,8 @@ function OpenNowBar(skipSaving: boolean = false) {
 
           // After seeking, update the timeline state to reflect the new position
           updateTimelineState();
+
+          SetControlsDragLock(false);
         };
 
         const timelineMaid = new Maid();
@@ -586,6 +605,12 @@ function OpenNowBar(skipSaving: boolean = false) {
           document.removeEventListener("touchmove", handleDragMove);
           document.removeEventListener("mouseup", handleDragEnd);
           document.removeEventListener("touchend", handleDragEnd);
+          if (isDragging) {
+            isDragging = false;
+            SliderBar.classList.remove("Dragging");
+            document.body.style.userSelect = "";
+            SetControlsDragLock(false);
+          }
         });
 
         // Run initial update
@@ -615,9 +640,219 @@ function OpenNowBar(skipSaving: boolean = false) {
         };
       };
 
+      const SetupVolumeControl = () => {
+        const VolumeElement = document.createElement("div");
+        VolumeElement.classList.add("VolumeControl");
+        // A vertical capsule in both progress-bar skins — same box, same drag axis.
+        // Only the paint differs, so both the fill (new skin) and the handle
+        // (legacy) are always present and CSS hides whichever doesn't apply.
+        VolumeElement.innerHTML = `
+                    <div class="VolumeFill"></div>
+                    <div class="Handle"></div>
+                    <div class="VolumeIcon">${Icons.Volume}</div>
+                `;
+
+        // Same trick the Heart uses — the SVG would otherwise swallow the clicks
+        // meant for the .VolumeIcon container.
+        const svgElement = VolumeElement.querySelector("svg");
+        if (svgElement) {
+          svgElement.style.pointerEvents = "none";
+          svgElement.querySelectorAll("path").forEach((path) => {
+            path.style.pointerEvents = "none";
+          });
+        }
+
+        const IconElement = VolumeElement.querySelector<HTMLElement>(".VolumeIcon");
+        if (!IconElement) {
+          console.error("Could not find VolumeControl elements");
+          return null;
+        }
+
+        const volumeMaid = new Maid();
+
+        let isDragging = false;
+        let currentLevel = 0;
+
+        const clamp = (value: number) => Math.max(0, Math.min(1, value));
+
+        // The glyph rests near the foot of the capsule (centered ~3cqh up a 32cqh
+        // track); once the fill's top edge clears it the icon sits on solid white,
+        // and .IconOnFill flips it from white to ink. Only the new skin acts on
+        // this class — the legacy skin's traveled colour keeps the glyph white.
+        const ICON_COVERED_LEVEL = 0.09;
+
+        // `getVolume()` returns 0 while muted and `toggleMute()` restores the previous
+        // level internally, so a single number drives both the bar and the icon —
+        // there's nothing to remember on our side and no `getMute()` call anywhere.
+        // Dragging to a genuine 0 therefore shows the muted icon, which is intended.
+
+        const render = (volume: number) => {
+          const level = clamp(volume);
+          currentLevel = level;
+          // One variable drives both skins: the new skin's fill scale and the
+          // legacy skin's gradient stop plus handle offset all read --VolumeLevel.
+          VolumeElement.style.setProperty("--VolumeLevel", level.toString());
+          VolumeElement.classList.toggle("IconOnFill", level >= ICON_COVERED_LEVEL);
+          VolumeElement.classList.toggle("Muted", level <= 0);
+          VolumeElement.classList.toggle("Low", level > 0 && level < 0.5);
+          VolumeElement.classList.toggle("High", level >= 0.5);
+        };
+
+        const commit = (volume: number) => {
+          const level = clamp(volume);
+          const wasMuted = currentLevel <= 0;
+          render(level);
+          try {
+            // Raising the bar out of a mute: lift the mute flag first, in case
+            // setVolume alone doesn't clear it.
+            if (wasMuted && level > 0) {
+              Spicetify.Player.setMute?.(false);
+            }
+            Spicetify.Player.setVolume(level);
+          } catch (err) {
+            console.error("Spicy Lyrics: couldn't set the volume", err);
+          }
+        };
+
+        const percentageFromEvent = (event: MouseEvent | TouchEvent) => {
+          let clientY: number;
+          if ("touches" in event && event.touches.length > 0) {
+            clientY = event.touches[0].clientY;
+          } else if ("changedTouches" in event && event.changedTouches.length > 0) {
+            clientY = event.changedTouches[0].clientY;
+          } else {
+            clientY = (event as MouseEvent).clientY;
+          }
+
+          const rect = VolumeElement.getBoundingClientRect();
+          if (rect.height === 0) return currentLevel;
+          return clamp(1 - (clientY - rect.top) / rect.height);
+        };
+
+        // Volume has no seek cost, so we commit live on every move instead of only
+        // on release like the timeline does. A plain click is covered too — mousedown
+        // starts the drag and immediately commits the position under the cursor.
+        const handleDragStart = (event: MouseEvent | TouchEvent) => {
+          // The glyph zone at the foot of the capsule is the mute button, not part
+          // of the track — starting a drag there would slam the volume to ~5% on
+          // every mute click.
+          if ((event.target as HTMLElement | null)?.closest?.(".VolumeIcon")) return;
+          isDragging = true;
+          // .Dragging keeps the capsule expanded and turns off the fill's eased
+          // glide so it tracks the pointer 1:1.
+          VolumeElement.classList.add("Dragging");
+          document.body.style.userSelect = "none";
+          // Keep the overlay from fading out when the pointer leaves the artwork
+          // while the fill is still held.
+          SetControlsDragLock(true);
+
+          document.addEventListener("mousemove", handleDragMove);
+          document.addEventListener("touchmove", handleDragMove);
+          document.addEventListener("mouseup", handleDragEnd);
+          document.addEventListener("touchend", handleDragEnd);
+
+          handleDragMove(event);
+        };
+
+        const handleDragMove = (event: MouseEvent | TouchEvent) => {
+          if (!isDragging) return;
+          commit(percentageFromEvent(event));
+        };
+
+        const handleDragEnd = (event: MouseEvent | TouchEvent) => {
+          if (!isDragging) return;
+          isDragging = false;
+          VolumeElement.classList.remove("Dragging");
+          document.body.style.userSelect = "";
+
+          document.removeEventListener("mousemove", handleDragMove);
+          document.removeEventListener("touchmove", handleDragMove);
+          document.removeEventListener("mouseup", handleDragEnd);
+          document.removeEventListener("touchend", handleDragEnd);
+
+          commit(percentageFromEvent(event));
+          SetControlsDragLock(false);
+        };
+
+        const iconHandler = () => {
+          try {
+            Spicetify.Player.toggleMute();
+          } catch (err) {
+            console.error("Spicy Lyrics: couldn't toggle mute", err);
+            return;
+          }
+
+          // The `volume` event normally drives the icon on its own; this one-shot
+          // resync covers the case where that internal emitter isn't available.
+          const resync = window.setTimeout(() => {
+            if (isDragging) return;
+            render(Spicetify.Player.getVolume() ?? 0);
+          }, 60);
+          volumeMaid.Give(() => clearTimeout(resync), "MuteResync");
+        };
+
+        const wheelHandler = (event: WheelEvent) => {
+          // Without this the lyrics underneath scroll along with the volume change.
+          event.preventDefault();
+          event.stopPropagation();
+          const step = 0.05;
+          commit(event.deltaY < 0 ? currentLevel + step : currentLevel - step);
+        };
+
+        VolumeElement.addEventListener("mousedown", handleDragStart);
+        VolumeElement.addEventListener("touchstart", handleDragStart);
+        IconElement.addEventListener("click", iconHandler);
+        VolumeElement.addEventListener("wheel", wheelHandler, { passive: false });
+
+        volumeMaid.Give(() => {
+          VolumeElement.removeEventListener("mousedown", handleDragStart);
+          VolumeElement.removeEventListener("touchstart", handleDragStart);
+          IconElement.removeEventListener("click", iconHandler);
+          VolumeElement.removeEventListener("wheel", wheelHandler);
+          document.removeEventListener("mousemove", handleDragMove);
+          document.removeEventListener("touchmove", handleDragMove);
+          document.removeEventListener("mouseup", handleDragEnd);
+          document.removeEventListener("touchend", handleDragEnd);
+          if (isDragging) {
+            isDragging = false;
+            VolumeElement.classList.remove("Dragging");
+            document.body.style.userSelect = "";
+            SetControlsDragLock(false);
+          }
+        });
+
+        // The `volume` event only fires on change, so seed the initial state here
+        // and let events drive it from then on.
+        render(Spicetify.Player.getVolume() ?? 0);
+
+        const cleanup = () => {
+          volumeMaid.Destroy();
+          if (VolumeElement.parentNode) {
+            VolumeElement.parentNode.removeChild(VolumeElement);
+          }
+        };
+
+        return {
+          Apply: () => {
+            AppendQueue.push(VolumeElement);
+          },
+          CleanUp: cleanup,
+          GetElement: () => VolumeElement,
+          SetVolume: (volume: number) => render(volume),
+          IsDragging: () => isDragging,
+        };
+      };
+
       ActivePlaybackControlsInstance = SetupPlaybackControls();
       if (ActivePlaybackControlsInstance) {
         ActivePlaybackControlsInstance.Apply();
+      }
+
+      if ($showVolumeSlider.get()) {
+        ActiveVolumeControlInstance = SetupVolumeControl();
+        if (ActiveVolumeControlInstance) {
+          ActiveVolumeControlInstance.Apply();
+        }
       }
 
       ActiveSetupSongProgressBarInstance = SetupSongProgressBar();
@@ -790,6 +1025,11 @@ function CleanUpActiveComponents() {
     // // console.log("Cleaned up SongProgressBar instance");
   }
 
+  if (ActiveVolumeControlInstance) {
+    ActiveVolumeControlInstance?.CleanUp();
+    ActiveVolumeControlInstance = null;
+  }
+
   if (ActiveSongProgressBarInstance_Map.size > 0) {
     ActiveSongProgressBarInstance_Map?.clear();
     // // console.log("Cleared SongProgressBar instance map");
@@ -809,6 +1049,9 @@ function CleanUpActiveComponents() {
 
     const timeline = MediaContent.querySelector(".Timeline");
     if (timeline) MediaContent.removeChild(timeline);
+
+    const volumeControl = MediaContent.querySelector(".VolumeControl");
+    if (volumeControl) MediaContent.removeChild(volumeControl);
   }
 
   // Also remove Timeline if it was placed in the Header
@@ -1356,6 +1599,16 @@ Global.Event.listen("playback:position", (e: number) => {
   }
 });
 
+Global.Event.listen("playback:volume", (volume: number) => {
+  if (!Fullscreen.IsOpen) return;
+  if (!$showVolumeSlider.get()) return;
+  if (!ActiveVolumeControlInstance) return;
+  // Every setVolume we issue echoes straight back as a volume event — applying it
+  // mid-drag would fight the handle under the cursor.
+  if (ActiveVolumeControlInstance.IsDragging()) return;
+  ActiveVolumeControlInstance.SetVolume(volume);
+});
+
 Global.Event.listen("fullscreen:exit", () => {
   CleanUpActiveComponents();
   CleanupMediaBox();
@@ -1381,6 +1634,24 @@ Global.Event.listen("compact-mode:disable", () => {
 
 $timelineOutsideMediaContent.subscribe(() => {
   RepositionTimeline();
+});
+
+// The band is built inside OpenNowBar's fullscreen block, so toggling the setting
+// has to rebuild the overlay components rather than just show/hide an element.
+// `.listen` (not `.subscribe`) — this must not fire on module load.
+$showVolumeSlider.listen(() => {
+  if (!Fullscreen.IsOpen) return;
+  CleanUpActiveComponents();
+  OpenNowBar(true);
+});
+
+// Experiments flagged `rebuildsNowBar` change the overlay's markup, not just its
+// CSS, so the components have to be rebuilt the same way the setting above does.
+onExperimentChange((experiment) => {
+  if (!experiment.rebuildsNowBar) return;
+  if (!Fullscreen.IsOpen) return;
+  CleanUpActiveComponents();
+  OpenNowBar(true);
 });
 
 export {

--- a/src/css/ContentBox.css
+++ b/src/css/ContentBox.css
@@ -886,10 +886,75 @@
   padding: 5cqw 7cqw;
 }
 
+/* Geometry shared by both progress-bar skins — only the skin below differs. */
 #SpicyLyricsPage .Timeline .SliderBar {
+  --SliderProgress: 0.6;
+  border-radius: 100cqw;
+  flex-grow: 1;
+  position: relative;
+  width: auto;
+  cursor: pointer;
+  margin: 0 1.5cqw;
+}
+
+/* ── Skin A — glass capsule (experiment "newProgressBarStyling") ────────────
+   Same language as the volume capsule: frosted track, white fill that IS the
+   progress, no handle dot. */
+#SpicyLyricsPage.Exp_NewProgressBar .Timeline .SliderBar {
+  height: 2.2cqh;
+  overflow: hidden;
+  background: var(--material-regular-bg);
+  -webkit-backdrop-filter: var(--material-regular-blur);
+  backdrop-filter: var(--material-regular-blur);
+  box-shadow:
+    0 6px 18px -8px rgba(8, 10, 18, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.18);
+  transition: height 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* iOS-style thickening while engaged — the vertical twin of the volume capsule's
+   width growth. .Timeline centers its children, so the bar grows symmetrically. */
+#SpicyLyricsPage.Exp_NewProgressBar .Timeline .SliderBar:is(:hover, .Dragging) {
+  height: 3cqh;
+}
+
+#SpicyLyricsPage.Exp_NewProgressBar .Timeline .SliderBar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  transform: scaleX(var(--SliderProgress));
+  transform-origin: left;
+  transition: transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Mid-drag the fill must track the pointer 1:1 — the eased glide is for playback
+   ticks and seeks only. */
+#SpicyLyricsPage.Exp_NewProgressBar .Timeline .SliderBar.Dragging::before {
+  transition: none;
+}
+
+/* The handle stays in the markup for the legacy skin; the fill replaces it here. */
+#SpicyLyricsPage.Exp_NewProgressBar .Timeline .SliderBar .Handle {
+  display: none;
+}
+
+/* The hoisted timeline's cq units resolve against the much taller NowBar container
+   rather than the square MediaBox, hence the smaller numbers for the same look. */
+#SpicyLyricsPage.Exp_NewProgressBar .Header > .Timeline .SliderBar {
+  height: 1.7cqh;
+}
+
+#SpicyLyricsPage.Exp_NewProgressBar .Header > .Timeline .SliderBar:is(:hover, .Dragging) {
+  height: 2.3cqh;
+}
+
+/* ── Skin B — legacy accent gradient + handle dot ──────────────────────────── */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .Timeline .SliderBar {
   --TraveledColor: var(--accent);
   --RemainingColor: var(--color-text-quaternary);
-  --SliderProgress: 0.6;
   background: linear-gradient(
     90deg,
     var(--TraveledColor) 0,
@@ -897,18 +962,24 @@
     var(--RemainingColor) calc(100% * var(--SliderProgress)),
     var(--RemainingColor)
   );
-  border-radius: 100cqw;
   container-type: size;
-  flex-grow: 1;
-  position: relative;
-  width: auto;
   height: 1.3cqh;
-  cursor: pointer;
-  margin: 0 1.5cqw;
 }
 
-#SpicyLyricsPage .Header > .Timeline .SliderBar {
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .Header > .Timeline .SliderBar {
   height: 1cqh;
+}
+
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .Timeline .SliderBar .Handle {
+  aspect-ratio: 1;
+  background: #fff;
+  border-radius: 100cqw;
+  display: block;
+  height: 185cqh;
+  left: calc(100cqw * var(--SliderProgress));
+  position: absolute;
+  top: 54cqh;
+  transform: translate(-50%, -50%);
 }
 
 #SpicyLyricsPage .Timeline .Time {
@@ -928,16 +999,328 @@
   text-align: left;
 }
 
-#SpicyLyricsPage .Timeline .SliderBar .Handle {
+/* --- Volume capsule -------------------------------------------------------- */
+/* A vertical, Control-Center-style capsule on the right edge of the artwork,
+   vertically centered — the one region that is empty in both timeline states, so
+   nothing else has to move to make room for it. Deliberately no `container-type`
+   here: cq units inside resolve against the square .MediaBox like every other
+   overlay band, and the handle's `%` offsets resolve against the capsule itself.
+
+   Geometry is shared by both progress-bar skins — position, size and placement
+   are identical whichever way the experiment is set; only the skin below differs. */
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  --VolumeLevel: 0;
+  /* Both are read back by the legacy handle — its diameter scales off the width,
+     its travel off the height — so PiP's wider capsule adapts for free and the
+     box is described in exactly one place. */
+  --CapsuleWidth: 4cqw;
+  --CapsuleHeight: 32cqh;
+  position: absolute;
+  top: 50%;
+  right: 4.5cqw;
+  translate: 0 -50%;
+  width: var(--CapsuleWidth);
+  height: var(--CapsuleHeight);
+  z-index: 2;
+  border-radius: 100cqw;
+  cursor: pointer;
+}
+
+/* ── Skin A — glass capsule (experiment "newProgressBarStyling") ────────────
+   The white fill IS the slider: no track line, no handle. */
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  overflow: hidden;
+  background: var(--material-regular-bg);
+  -webkit-backdrop-filter: var(--material-regular-blur);
+  backdrop-filter: var(--material-regular-blur);
+  box-shadow:
+    0 10px 24px -8px rgba(8, 10, 18, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.18);
+  transition: width 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* iOS-style thickening while engaged. Width-anchored right, so it grows inward.
+   Skin A only — a handle dot alongside a growing track reads as two competing
+   affordances. */
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl:is(:hover, .Dragging) {
+  --CapsuleWidth: 5.4cqw;
+}
+
+#SpicyLyricsPage.Exp_NewProgressBar .VolumeControl .VolumeFill {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  transform: scaleY(var(--VolumeLevel));
+  transform-origin: bottom;
+  transition: transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
+  pointer-events: none;
+}
+
+/* Mid-drag the fill must track the pointer 1:1 — the eased glide is only for
+   wheel steps, mute snaps and external volume changes. */
+#SpicyLyricsPage.Exp_NewProgressBar .VolumeControl.Dragging .VolumeFill {
+  transition: none;
+}
+
+/* Skin B draws the level as a background gradient instead. */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .VolumeControl .VolumeFill {
+  display: none;
+}
+
+/* ── Skin B — legacy accent gradient + handle dot ──────────────────────────
+   The vertical twin of the old horizontal bar: a hard-stop gradient painted on
+   the track itself, so both ends stay perfectly rounded at any level and no fill
+   element is involved. Placement and height match Skin A exactly; only the track's
+   thickness differs, because a flat line and a frosted capsule want different
+   weights to read correctly.
+
+   .Fullscreen.ShowVolumeSlider are carried here only to out-specify the shared
+   geometry rule above, which would otherwise win --CapsuleWidth. */
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider:not(.Exp_NewProgressBar)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  /* The old bar was a 1.3cq-thick line, not a capsule — the glass skin's 4cqw is
+     thickness the frosted material needs to read as a material, and it looks
+     bloated with a flat fill. The handle scales off this, so it shrinks to match. */
+  --CapsuleWidth: 1.3cqw;
+  --TraveledColor: var(--accent);
+  --RemainingColor: var(--color-text-quaternary);
+  background: linear-gradient(
+    0deg,
+    var(--TraveledColor) 0,
+    var(--TraveledColor) calc(100% * var(--VolumeLevel)),
+    var(--RemainingColor) calc(100% * var(--VolumeLevel)),
+    var(--RemainingColor)
+  );
+}
+
+/* A 1.3cqw line is a hard thing to grab. Widen the hit area without touching the
+   paint — the pointer target is what the user aims at, not what they see. */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .VolumeControl::after {
+  content: "";
+  position: absolute;
+  inset: 0 -2.5cqw;
+}
+
+/* Sized off the capsule width exactly as the old handle was sized off the bar's
+   thickness (1.85×), so it overhangs the track the same way — the capsule stays
+   `overflow: visible` in this skin to let it. Rides the top edge of the traveled
+   segment via transform rather than `bottom`, which keeps it off the layout path
+   and lets it glide with the same curve Skin A's fill uses. */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .VolumeControl .Handle {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: calc(var(--CapsuleWidth) * 1.85);
   aspect-ratio: 1;
   background: #fff;
-  border-radius: 100cqw;
-  display: block;
-  height: 185cqh;
-  left: calc(100cqw * var(--SliderProgress));
+  border-radius: 50%;
+  transform: translate(-50%, 50%)
+    translateY(calc(-1 * var(--CapsuleHeight) * var(--VolumeLevel)));
+  transition: transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
+  pointer-events: none;
+}
+
+/* Mid-drag the handle must track the pointer 1:1, same as Skin A's fill. */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .VolumeControl.Dragging .Handle {
+  transition: none;
+}
+
+/* Skin A replaces the handle with the fill. */
+#SpicyLyricsPage.Exp_NewProgressBar .VolumeControl .Handle {
+  display: none;
+}
+
+/* The mute button. Drags never start on it — see SetupVolumeControl. */
+#SpicyLyricsPage .VolumeControl .VolumeIcon {
   position: absolute;
-  top: 54cqh;
-  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  fill: #fff;
+  /* Above the track's hit-area expander so the click reaches the glyph. */
+  z-index: 1;
+  transition: fill 0.15s ease;
+}
+
+/* Skin A: inside the capsule, at its foot — the glass track is thick enough to
+   hold the glyph, and the fill sliding up behind it is the point. */
+#SpicyLyricsPage.Exp_NewProgressBar .VolumeControl .VolumeIcon {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 6cqh;
+}
+
+/* Skin B: below the track. The legacy bar is a thin line with a handle riding it —
+   there is no room inside, and the white handle passing behind a white glyph would
+   swallow it. This is where the old horizontal band put the icon, rotated. */
+#SpicyLyricsPage:not(.Exp_NewProgressBar) .VolumeControl .VolumeIcon {
+  top: calc(100% + 2cqh);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6cqw;
+  height: 5cqh;
+}
+
+/* The white fill has risen past the glyph, so flip it to ink. Skin A only —
+   Skin B's traveled segment is the accent colour, which the white glyph reads
+   against fine and dark ink would not. */
+#SpicyLyricsPage.Exp_NewProgressBar .VolumeControl.IconOnFill .VolumeIcon {
+  fill: rgba(0, 0, 0, 0.68);
+}
+
+#SpicyLyricsPage .VolumeControl .VolumeIcon svg {
+  height: 2.6cqh;
+  width: auto;
+  pointer-events: none;
+  transition: transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+#SpicyLyricsPage .VolumeControl .VolumeIcon:active svg {
+  transform: scale(0.85);
+}
+
+#SpicyLyricsPage .VolumeControl #SpicyLyrics_VolumeWaveLow,
+#SpicyLyricsPage .VolumeControl #SpicyLyrics_VolumeWaveHigh,
+#SpicyLyricsPage .VolumeControl #SpicyLyrics_VolumeMute {
+  transition: opacity 0.18s ease;
+}
+
+/* The level alone decides the icon: 0 is muted, one threshold splits low from high. */
+#SpicyLyricsPage .VolumeControl #SpicyLyrics_VolumeMute {
+  opacity: 0;
+}
+
+#SpicyLyricsPage .VolumeControl.Low #SpicyLyrics_VolumeWaveHigh {
+  opacity: 0;
+}
+
+#SpicyLyricsPage .VolumeControl.Muted #SpicyLyrics_VolumeWaveLow,
+#SpicyLyricsPage .VolumeControl.Muted #SpicyLyrics_VolumeWaveHigh {
+  opacity: 0;
+}
+
+#SpicyLyricsPage .VolumeControl.Muted #SpicyLyrics_VolumeMute {
+  opacity: 1;
+}
+
+/* PiP (~390px) and compact mode render the artwork small, which makes the track
+   skinny in absolute pixels — widen it relative to the box, mirroring the
+   .PlaybackControl overrides above. The inset is shared; the thickness is not,
+   since the two skins start from very different widths. */
+.spicy-pip-wrapper
+  #SpicyLyricsPage.Fullscreen.ShowVolumeSlider
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl,
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider:is(.CompactMode, .ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  right: 4cqw;
+}
+
+.spicy-pip-wrapper
+  #SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl,
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar:is(.CompactMode, .ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  --CapsuleWidth: 6.5cqw;
+}
+
+.spicy-pip-wrapper
+  #SpicyLyricsPage.Fullscreen.ShowVolumeSlider:not(.Exp_NewProgressBar)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl,
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider:not(.Exp_NewProgressBar):is(.CompactMode, .ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl {
+  --CapsuleWidth: 2.2cqw;
+}
+
+.spicy-pip-wrapper
+  #SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl:is(:hover, .Dragging),
+#SpicyLyricsPage.Fullscreen.ShowVolumeSlider.Exp_NewProgressBar:is(.CompactMode, .ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .CenteredView
+  .Header
+  .MediaBox
+  .MediaContent
+  .VolumeControl:is(:hover, .Dragging) {
+  --CapsuleWidth: 8cqw;
+}
+
+.spicy-pip-wrapper #SpicyLyricsPage .VolumeControl .VolumeIcon svg,
+#SpicyLyricsPage:is(.CompactMode, .ForcedCompactMode) .VolumeControl .VolumeIcon svg {
+  height: 3.4cqh;
 }
 
 #SpicyLyricsPage.Fullscreen .Separator {

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -835,7 +835,7 @@
   opacity: 1;
 }
 
-#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer:not([data-lyrics-type="Static"]) .line:not(.musical-line)::before {
+#SpicyLyricsPage.SpicyRenderer:not(.NoLineHoverBackground) .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer:not([data-lyrics-type="Static"]) .line:not(.musical-line)::before {
   content: "";
   position: absolute;
   top: 50%;
@@ -851,7 +851,7 @@
   transform-origin: center center;
 }
 
-#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer:not([data-lyrics-type="Static"]) .line:hover::before {
+#SpicyLyricsPage.SpicyRenderer:not(.NoLineHoverBackground) .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer:not([data-lyrics-type="Static"]) .line:hover::before {
   opacity: 1;
   scale: 1.05;
 }

--- a/src/css/NPVLyrics.css
+++ b/src/css/NPVLyrics.css
@@ -79,9 +79,17 @@
 }
 
 /* Body hosts the absolutely-positioned, container-type:size page. */
+/* flex-shrink: 0 matters for the open/close morph: as a shrinkable flex item the
+   body absorbed the card's animated height, so every frame re-resolved the
+   page's cqw/cqh type scale, relaid out every mounted line, and re-triggered the
+   virtualizer's measure/mount cycle. Pinned, the body keeps its final size from
+   frame 0 and the card's `overflow: hidden` simply clips it into view — the
+   lyrics are laid out once. (.Expanded overrides this with `flex: 1 1 auto`,
+   where the body is meant to flex.) */
 #SpicyLyricsNPVCard .CardBody {
   position: relative;
   height: 225px;
+  flex-shrink: 0;
 }
 
 /* Collapsed shell: header only. */

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -620,6 +620,72 @@ sl-generic-modal.SpicyLyricsModal .sl-modal-overlay {
     }
   }
 
+  /* ── Panel navigation (Settings ⇄ sub-panels) ─────────────────────────
+     The modal frame stays put; only its contents slide. Forward enters from
+     the right, back from the left, so the direction of travel reads at a
+     glance. Short and ease-out — this is navigation, not decoration. */
+  .sl-sp-page--forward {
+    animation: sl-sp-page-in-forward 0.22s cubic-bezier(0.23, 1, 0.32, 1) both;
+  }
+
+  .sl-sp-page--back {
+    animation: sl-sp-page-in-back 0.22s cubic-bezier(0.23, 1, 0.32, 1) both;
+  }
+
+  /* Sub-panel header — holds the back affordance above the rows. */
+  .sl-sp-subheader {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--space-3);
+  }
+
+  .sl-sp-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 6px 12px 6px 8px;
+    cursor: pointer;
+    background: var(--accent-tint-bg);
+    color: var(--color-text-secondary);
+    box-shadow: inset 0 0 0 1px var(--hairline);
+    font-size: var(--text-caption-size) !important;
+    font-weight: var(--w-semibold);
+    transition:
+      background var(--dur-fast) var(--ease-standard),
+      color var(--dur-fast) var(--ease-standard),
+      box-shadow var(--dur-fast) var(--ease-standard),
+      transform 0.12s ease;
+
+    svg {
+      transition: transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
+    }
+
+    &:hover {
+      background: var(--accent-tint-bg-hover);
+      color: var(--color-text-primary);
+      box-shadow: inset 0 0 0 1px var(--hairline-strong);
+    }
+
+    /* The chevron leads the way back. */
+    &:hover svg {
+      transform: translateX(-2px);
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+  }
+
+  .sl-sp-experiments-note {
+    color: var(--color-text-secondary);
+    font-size: var(--text-footnote-size) !important;
+    font-weight: var(--w-regular);
+    line-height: 1.45;
+    margin: 0 0 var(--space-4);
+  }
+
   /* Inline action button (Reset, Clear, etc.) — flat tinted surface */
   .sl-sp-btn {
     border: none;
@@ -644,6 +710,37 @@ sl-generic-modal.SpicyLyricsModal .sl-modal-overlay {
 
     &:active {
       transform: scale(0.97);
+    }
+  }
+}
+
+/* Small offsets — the panel is telling you which way you moved, not putting on
+   a show. Opacity carries most of the swap; the shift just gives it direction. */
+@keyframes sl-sp-page-in-forward {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+}
+
+@keyframes sl-sp-page-in-back {
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+}
+
+/* Keep the fade (it explains that the content changed); drop the movement. */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes sl-sp-page-in-forward {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes sl-sp-page-in-back {
+    from {
+      opacity: 0;
     }
   }
 }

--- a/src/utils/API/Query.ts
+++ b/src/utils/API/Query.ts
@@ -1,6 +1,6 @@
 import Defaults from "../../components/Global/Defaults.ts";
 import Session from "../../components/Global/Session.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 export type Query = {
   operation: string;

--- a/src/utils/IntervalManager.ts
+++ b/src/utils/IntervalManager.ts
@@ -1,5 +1,5 @@
 import { Maid } from "../modules/Maid";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const intervalLogger = new Logger("Interval Manager");
 

--- a/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
+++ b/src/utils/Lyrics/Applyer/CreateLyricsContainer.ts
@@ -21,8 +21,16 @@ const CreateLyricsContainer = (): LyricsContainerReturnObject => {
   lastMapIndex += 1;
   const currentIndex = lastMapIndex;
 
+  // Coalesce to one pass per frame. Each ResizeObserver callback used to queue
+  // its own rAF, so a burst (or anything that resizes the container every frame,
+  // like the NPV card's open/close morph) stacked several SimpleBar
+  // recalculate() calls — each a forced layout — onto the same frame.
+  let resizeRAF: number | null = null;
+
   const Resize = () => {
-    requestAnimationFrame(() => {
+    if (resizeRAF !== null) return;
+    resizeRAF = requestAnimationFrame(() => {
+      resizeRAF = null;
       QueueForceScroll();
       ScrollSimplebar?.recalculate();
     });
@@ -33,6 +41,10 @@ const CreateLyricsContainer = (): LyricsContainerReturnObject => {
   });
 
   const Remove = () => {
+    if (resizeRAF !== null) {
+      cancelAnimationFrame(resizeRAF);
+      resizeRAF = null;
+    }
     ResizeListener.unobserve(Container.parentElement as HTMLElement);
     ResizeListener.disconnect();
     Container.remove();

--- a/src/utils/Lyrics/LyricsQueueRetry.ts
+++ b/src/utils/Lyrics/LyricsQueueRetry.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import Global from "../../components/Global/Global.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import ApplyLyrics from "./Global/Applyer.ts";
 import fetchLyrics, { ShowQueueLoader } from "./fetchLyrics.ts";
 

--- a/src/utils/Lyrics/LyricsVirtualizer.ts
+++ b/src/utils/Lyrics/LyricsVirtualizer.ts
@@ -5,7 +5,7 @@ import {
   observeElementOffset,
 } from "@tanstack/virtual-core";
 import { Maid } from "../../modules/Maid.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Gap scale factors relative to 1cqw (containerWidth / 100).
 // Gap is baked into each wrapper's padding-bottom so items can have

--- a/src/utils/Lyrics/LyricsVirtualizer.ts
+++ b/src/utils/Lyrics/LyricsVirtualizer.ts
@@ -846,19 +846,30 @@ class LyricsVirtualizer {
     // Diagnostics: distinguishes a smooth-scroll stall, an unscrollable container,
     // and the Wayland failure — a DOM/virtualizer offset desync (observedScrollTop
     // moved but tanstackOffset did not, because the 'scroll' event never dispatched).
-    virtualizerLogger.debug("scrollToIndex applied", {
-      retry,
-      finalScrollTop: Math.round(finalScrollTop),
-      observedScrollTop: Math.round(observedScrollTop),
-      tanstackOffset: tanstackOffsetBefore == null ? null : Math.round(tanstackOffsetBefore),
-      scrollHeight: scrollEl.scrollHeight,
-      clientHeight: scrollEl.clientHeight,
-      maxScroll: scrollEl.scrollHeight - scrollEl.clientHeight,
-      virtualHeight: this._virtualContainer.offsetHeight,
-      scrollBehavior: getComputedStyle(scrollEl).scrollBehavior,
-      hasInstantScroll: scrollEl.classList.contains("InstantScroll"),
-      targetMounted: this._mountedIndices.has(index),
-    });
+    //
+    // Gated on isEnabled rather than left to Logger.debug's own early return:
+    // arguments are evaluated at the call site, so building this payload cost a
+    // forced style recalc (getComputedStyle) plus five layout reads on EVERY
+    // retry — up to 31 per scroll — even with developer mode off. Sitting between
+    // the scrollTo() above and the measureElement() reads below, that turned the
+    // convergence chain into sustained layout thrash while the lyrics render.
+    if (virtualizerLogger.isEnabled) {
+      const scrollHeight = scrollEl.scrollHeight;
+      const clientHeight = scrollEl.clientHeight;
+      virtualizerLogger.debug("scrollToIndex applied", {
+        retry,
+        finalScrollTop: Math.round(finalScrollTop),
+        observedScrollTop: Math.round(observedScrollTop),
+        tanstackOffset: tanstackOffsetBefore == null ? null : Math.round(tanstackOffsetBefore),
+        scrollHeight,
+        clientHeight,
+        maxScroll: scrollHeight - clientHeight,
+        virtualHeight: this._virtualContainer.offsetHeight,
+        scrollBehavior: getComputedStyle(scrollEl).scrollBehavior,
+        hasInstantScroll: scrollEl.classList.contains("InstantScroll"),
+        targetMounted: this._mountedIndices.has(index),
+      });
+    }
 
     // Wayland quirk: a programmatic scrollTop write may not dispatch a 'scroll' event,
     // so observeElementOffset never updates scrollOffset and the virtual window stays

--- a/src/utils/Lyrics/ProcessLyrics.ts
+++ b/src/utils/Lyrics/ProcessLyrics.ts
@@ -5,7 +5,7 @@ import langs from "langs";
 import { RetrievePackage } from "../ImportPackage.ts";
 import * as KuromojiAnalyzer from "./KuromojiAnalyzer.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 
 // Constants
 const RomajiConverter = new Kuroshiro();

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -5,7 +5,7 @@ import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import PageView, { PageContainer } from "../../components/Pages/PageView.ts";
 import { Query } from "../API/Query.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import { LocalLyricsManager } from "./manager/index.ts";
 import { LyricsQueueRetry } from "./LyricsQueueRetry.ts";
 import { GetExpireStore } from "../../modules/Store.ts";

--- a/src/utils/Lyrics/manager/index.ts
+++ b/src/utils/Lyrics/manager/index.ts
@@ -1,5 +1,5 @@
 import { dbPromise, ObjectStores } from "../../db";
-import Logger from "../../logger";
+import Logger from "../../Logger";
 import { ParseTTML } from "./parseTTML";
 
 const logger = new Logger("Local Lyrics Manager");

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -22,6 +22,9 @@ type EnhancedLyricsItem = LyricsLineWithIndex | LyricsSyllableWithIndex;
 // Define proper types for variables
 let lastLine: HTMLElement | null = null;
 let lastLineIndex: number | null = null;
+// The lyrics array that lastLineIndex refers to. When the active lyrics swap
+// (new track / type change) this identity changes, invalidating the stale index.
+let lastLinesRef: LyricsLine[] | LyricsSyllable[] | null = null;
 let isUserScrolling = false;
 let lastUserScrollTime = 0;
 let lastPosition: number = 0;
@@ -230,6 +233,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     lastLine = scrollToLine;
     const forceScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
     lastLineIndex = forceScrollLineIndex ?? null;
+    lastLinesRef = Lines;
     ScrollTo(
       container,
       scrollToLine,
@@ -258,6 +262,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     lastLine = scrollToLine;
     const smoothScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
     lastLineIndex = smoothScrollLineIndex ?? null;
+    lastLinesRef = Lines;
     ScrollTo(container, scrollToLine, false, GetScrollType(), smoothScrollLineIndex);
     if (smoothForceScrollQueued) {
       smoothForceScrollQueued = false; // Reset the queue after using it
@@ -433,10 +438,13 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
         //}
         // Scroll if the line is different from the last auto-scrolled line
         const isScrollingUp =
-          lastLineIndex !== null && currentLine._LineIndex < lastLineIndex;
+          lastLineIndex !== null &&
+          lastLinesRef === Lines &&
+          currentLine._LineIndex < lastLineIndex;
         if (!isSameLine && (isScrollingUp ? $allowScrollUp.get() : true)) {
           lastLine = LineElem;
           lastLineIndex = currentLine._LineIndex;
+          lastLinesRef = Lines;
           const Scroll = () => {
             ScrollTo(container, LineElem, false, GetScrollType(), currentLine._LineIndex);
             scrolledToLastLine = false;
@@ -470,6 +478,7 @@ export function QueueSmoothForceScroll() {
 export function ResetLastLine() {
   lastLine = null;
   lastLineIndex = null;
+  lastLinesRef = null;
   lastViewportLine = null;
   lastViewportContainer = null;
   lastIsLineInViewport = false;

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -1,4 +1,4 @@
-import { $currentLyricsType, $lyricsContainerExists } from "../../utils/stores.ts";
+import { $allowScrollUp, $currentLyricsType, $lyricsContainerExists } from "../../utils/stores.ts";
 import Global from "../../components/Global/Global.ts";
 import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import { PageContainer } from "../../components/Pages/PageView.ts";
@@ -21,6 +21,7 @@ type EnhancedLyricsItem = LyricsLineWithIndex | LyricsSyllableWithIndex;
 
 // Define proper types for variables
 let lastLine: HTMLElement | null = null;
+let lastLineIndex: number | null = null;
 let isUserScrolling = false;
 let lastUserScrollTime = 0;
 let lastPosition: number = 0;
@@ -228,6 +229,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     if (!scrollToLine) return;
     lastLine = scrollToLine;
     const forceScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
+    lastLineIndex = forceScrollLineIndex ?? null;
     ScrollTo(
       container,
       scrollToLine,
@@ -255,6 +257,7 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
     if (!scrollToLine) return;
     lastLine = scrollToLine;
     const smoothScrollLineIndex = allLinesSung ? Lines.length - 1 : currentLine?._LineIndex;
+    lastLineIndex = smoothScrollLineIndex ?? null;
     ScrollTo(container, scrollToLine, false, GetScrollType(), smoothScrollLineIndex);
     if (smoothForceScrollQueued) {
       smoothForceScrollQueued = false; // Reset the queue after using it
@@ -429,8 +432,11 @@ export function ScrollToActiveLine(ScrollSimplebar: any) {
         }
         //}
         // Scroll if the line is different from the last auto-scrolled line
-        if (!isSameLine) {
+        const isScrollingUp =
+          lastLineIndex !== null && currentLine._LineIndex < lastLineIndex;
+        if (!isSameLine && (isScrollingUp ? $allowScrollUp.get() : true)) {
           lastLine = LineElem;
+          lastLineIndex = currentLine._LineIndex;
           const Scroll = () => {
             ScrollTo(container, LineElem, false, GetScrollType(), currentLine._LineIndex);
             scrolledToLastLine = false;
@@ -463,6 +469,7 @@ export function QueueSmoothForceScroll() {
 
 export function ResetLastLine() {
   lastLine = null;
+  lastLineIndex = null;
   lastViewportLine = null;
   lastViewportContainer = null;
   lastIsLineInViewport = false;

--- a/src/utils/SessionManager/SessionManager.ts
+++ b/src/utils/SessionManager/SessionManager.ts
@@ -1,5 +1,5 @@
 import Platform from "../../components/Global/Platform.ts";
-import Logger from "../logger.ts";
+import Logger from "../Logger.ts";
 import {
   applyPingConfig,
   BACKOFF_BASE_MS,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,5 +1,5 @@
 import { openDB } from "idb";
-import Logger from "./logger";
+import Logger from "./Logger";
 
 const dbLogger = new Logger("Database");
 

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -1,0 +1,95 @@
+import { persistAtom } from "./stores.ts";
+
+/**
+ * ─── Experiments ──────────────────────────────────────────────────────────────
+ *
+ * Opt-in/opt-out feature flags surfaced in Settings → Experiments.
+ *
+ * TO ADD AN EXPERIMENT: append one entry to the EXPERIMENTS array below. That is
+ * the whole registration — the settings UI, the persisted store and (if you set
+ * `pageClass`) the CSS hook are all derived from it. Nothing else to wire up.
+ *
+ *   {
+ *     id: "myExperiment",              // stable; persisted as "experiment:myExperiment"
+ *     label: "My Experiment",
+ *     description: "What it changes, and what turning it off restores.",
+ *     default: true,
+ *     pageClass: "Exp_MyExperiment",   // optional — toggled on #SpicyLyricsPage
+ *     rebuildsNowBar: true,            // optional — see below
+ *   }
+ *
+ * `pageClass` is the preferred way to implement one: write the new look under
+ * `#SpicyLyricsPage.Exp_Foo` and keep the old one under
+ * `#SpicyLyricsPage:not(.Exp_Foo)`, and the toggle costs nothing at runtime.
+ *
+ * `rebuildsNowBar` is only for experiments whose *markup* differs between states
+ * (CSS alone can't get you there). It makes NowBar tear down and rebuild the
+ * fullscreen overlay when the flag flips.
+ */
+
+export type Experiment = {
+  /** Stable key. Persisted in the settings blob as `experiment:<id>`. */
+  id: string;
+  label: string;
+  description: string;
+  default: boolean;
+  /** Class toggled on `#SpicyLyricsPage` while the experiment is enabled. */
+  pageClass?: string;
+  /** Rebuild the fullscreen NowBar overlay when this flag changes. */
+  rebuildsNowBar?: boolean;
+};
+
+export const EXPERIMENTS = [
+  {
+    id: "newProgressBarStyling",
+    label: "New ProgressBar Styling",
+    description:
+      "Frosted glass progress and volume bars, where a solid fill replaces the handle. Turn off to go back to the previous look — an accent-coloured track with a handle. Only the styling changes; both bars keep their current size and position either way.",
+    default: true,
+    pageClass: "Exp_NewProgressBar",
+  },
+] as const satisfies readonly Experiment[];
+
+/** A registry entry, narrowed to its literal `id` — what the UI iterates over. */
+export type RegisteredExperiment = (typeof EXPERIMENTS)[number];
+export type ExperimentId = RegisteredExperiment["id"];
+
+const makeStore = (key: string, defaultValue: boolean) => persistAtom<boolean>(key, defaultValue);
+type ExperimentStore = ReturnType<typeof makeStore>;
+
+const stores = new Map<string, ExperimentStore>(
+  EXPERIMENTS.map((exp) => [exp.id, makeStore(`experiment:${exp.id}`, exp.default)])
+);
+
+/** The persisted store for an experiment — use in React via `useStore`. */
+export function $experiment(id: ExperimentId): ExperimentStore {
+  const store = stores.get(id);
+  if (!store) throw new Error(`Unknown experiment "${id}"`);
+  return store;
+}
+
+export function isExperimentEnabled(id: ExperimentId): boolean {
+  return stores.get(id)?.get() ?? false;
+}
+
+export function setExperiment(id: ExperimentId, value: boolean): void {
+  stores.get(id)?.set(value);
+}
+
+/** Sync every experiment's `pageClass` onto the page root. Safe to call anytime. */
+export function ApplyExperimentClasses(el: HTMLElement): void {
+  for (const exp of EXPERIMENTS) {
+    if (!exp.pageClass) continue;
+    el.classList.toggle(exp.pageClass, isExperimentEnabled(exp.id));
+  }
+}
+
+/**
+ * Run `cb(experiment)` whenever any experiment is toggled. `.listen` rather than
+ * `.subscribe`, so this never fires on module load.
+ */
+export function onExperimentChange(cb: (experiment: Experiment) => void): void {
+  for (const exp of EXPERIMENTS) {
+    stores.get(exp.id)?.listen(() => cb(exp));
+  }
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,19 +1,68 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { flushSync } from "react-dom";
 import { PopupModal } from "../components/Modal.ts";
 import SettingsPanel from "../components/ReactComponents/SettingsPanel/index.tsx";
+import ExperimentsPanel from "../components/ReactComponents/SettingsPanel/ExperimentsPanel.tsx";
+
+const MODAL_ID = "settingsPanel";
+
+type Direction = "forward" | "back";
+
+/**
+ * Render a panel into a fresh container + root. The direction class drives the
+ * slide-in, so the modal frame stays put while its contents navigate.
+ */
+function renderPanel(element: React.ReactElement, direction?: Direction) {
+  const container = document.createElement("div");
+  container.className = direction ? `sl-sp-page sl-sp-page--${direction}` : "sl-sp-page";
+  const root = ReactDOM.createRoot(container);
+  // Render synchronously so the modal never shows an empty frame mid-swap.
+  flushSync(() => root.render(element));
+  return { container, root };
+}
 
 export function openSettingsPanel() {
-  const container = document.createElement("div");
-  const root = ReactDOM.createRoot(container);
-  root.render(React.createElement(SettingsPanel));
+  const { container, root } = renderPanel(
+    React.createElement(SettingsPanel, { onOpenExperiments: openExperimentsPanel })
+  );
+
   PopupModal.display({
     title: "Settings",
     content: container,
     isLarge: true,
-    modalId: "settingsPanel",
-    onClose: () => {
-      root.unmount();
-    },
+    modalId: MODAL_ID,
+    onClose: () => root.unmount(),
+  });
+}
+
+/** Back navigation from a sub-panel — swaps content without reopening the modal. */
+function backToSettings() {
+  const { container, root } = renderPanel(
+    React.createElement(SettingsPanel, { onOpenExperiments: openExperimentsPanel }),
+    "back"
+  );
+
+  PopupModal.transition({
+    title: "Settings",
+    content: container,
+    modalId: MODAL_ID,
+    onClose: () => root.unmount(),
+  });
+}
+
+function openExperimentsPanel() {
+  const { container, root } = renderPanel(
+    React.createElement(ExperimentsPanel, { onBack: backToSettings }),
+    "forward"
+  );
+
+  // No closeHandler: the X closes the modal outright, and the panel's own Back
+  // button is what returns to Settings.
+  PopupModal.transition({
+    title: "Experiments",
+    content: container,
+    modalId: MODAL_ID,
+    onClose: () => root.unmount(),
   });
 }

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -36,7 +36,12 @@ function migrateSettingsKeys(blob: Record<string, any>): Record<string, any> {
 
 const _settings: Record<string, any> = migrateSettingsKeys(readSettingsBlob());
 
-function persistAtom<T>(key: string, defaultValue: T) {
+/**
+ * An atom backed by the settings blob. Exported so feature modules (e.g.
+ * `experiments.ts`) can register their own persisted settings without having to
+ * add a line here for every one.
+ */
+export function persistAtom<T>(key: string, defaultValue: T) {
   const store = atom<T>(_settings[key] !== undefined ? _settings[key] : defaultValue);
   store.listen((v) => {
     _settings[key] = v;
@@ -55,8 +60,12 @@ export const $simpleLyricsModeRenderingType = persistAtom<string>(
   "calculate"
 );
 export const $minimalLyricsMode = persistAtom<boolean>("minimalLyricsMode", false);
+// Tinted box drawn behind a lyrics line while the pointer is over it.
+export const $lineHoverBackground = persistAtom<boolean>("lineHoverBackground", true);
 export const $skipSpicyFont = persistAtom<boolean>("skipSpicyFont", false);
 export const $showNpvDynamicBg = persistAtom<boolean>("showNpvDynamicBg", true);
+// Never inject the lyrics card into the Now Playing sidebar at all.
+export const $disableNpvLyrics = persistAtom<boolean>("disableNpvLyrics", false);
 // Pull the whole NPV lyrics card out of the sidebar while the current track has
 // no lyrics, instead of leaving it up showing the "no lyrics" notice.
 export const $hideNpvLyricsWhenUnavailable = persistAtom<boolean>(
@@ -83,6 +92,8 @@ export const $timelineOutsideMediaContent = persistAtom<boolean>(
   "timelineOutsideMediaContent",
   true
 );
+// Volume band below the playback controls in Fullscreen / Cinema View / Popup Lyrics.
+export const $showVolumeSlider = persistAtom<boolean>("showVolumeSlider", true);
 // Playback timing offset in milliseconds (bipolar: negative = earlier, positive = later)
 export const $playbackOffset = persistAtom<number>("playbackOffset", 0);
 

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -56,6 +56,7 @@ export const $minimalLyricsMode = persistAtom<boolean>("minimalLyricsMode", fals
 export const $skipSpicyFont = persistAtom<boolean>("skipSpicyFont", false);
 export const $showNpvDynamicBg = persistAtom<boolean>("showNpvDynamicBg", true);
 export const $lockedMediaBox = persistAtom<boolean>("lockedMediaBox", false);
+export const $allowScrollUp = persistAtom<boolean>("allowScrollUp", true);
 // $popupLyricsAllowed: stored as actual boolean "popupLyricsAllowed" in the settings blob.
 export const $popupLyricsAllowed = (() => {
   const initial: boolean =


### PR DESCRIPTION
# Update 6.3.0
- Add volume slider into fullscreen/cinema view views
  - Can be disabled/enabled through the settings
- Add `Experiments` panel
  - Allows you to enable/disable certain features that are still in testing
- Add new progress/slider bar look (can be reverted to the old one in the new experiments panel)
- Add a "Allow scrolling up" toggle
  - #334 
- Add a "Line Hover Background" toggle – ability to hide the line hover background container
- Add "Disable NPV Lyrics" – ability to fully hide and remove the NPV lyrics card
- Performance improvements for the initial lyrics render
- Bugfixes for the NPV lyrics card