### PR TITLE
Add proof-of-concept vertical NowBar layout positions

### DIFF
--- a/src/components/Pages/PageView.ts
+++ b/src/components/Pages/PageView.ts
@@ -696,7 +696,7 @@ function AppendViewControls(ReAppend: boolean = false) {
         if (!isPip) {
           Tooltips.NowBarSideToggle = Spicetify.Tippy(nowBarSideToggleBtn, {
             ...Spicetify.TippyProps,
-            content: `Swap NowBar Side`,
+            content: `Change NowBar Position`,
           });
         }
         nowBarSideToggleBtn.addEventListener("click", () => NowBar_SwapSides());

--- a/src/components/Utils/CompactMode.ts
+++ b/src/components/Utils/CompactMode.ts
@@ -23,11 +23,11 @@ export const EnableCompactMode = () => {
   }
 
   SpicyLyricsPage.classList.add("CompactMode", "NowBarSide__Left");
-  SpicyLyricsPage.classList.remove("NowBarSide__Right");
+  SpicyLyricsPage.classList.remove("NowBarSide__Right", "NowBarSide__Top", "NowBarSide__Bottom");
   const NowBar = SpicyLyricsPage.querySelector<HTMLElement>(".ContentBox .NowBar");
   if (!NowBar) return;
   NowBar.classList.add("LeftSide");
-  NowBar.classList.remove("RightSide");
+  NowBar.classList.remove("RightSide", "TopSide", "BottomSide");
 
   if (!IsPIP) {
     if ($lockedMediaBox.get()) {

--- a/src/components/Utils/NowBar.ts
+++ b/src/components/Utils/NowBar.ts
@@ -57,6 +57,46 @@ export const NowBarObj = {
   Open: false,
 };
 
+type NowBarSide = "left" | "right" | "top" | "bottom";
+
+const NOW_BAR_SIDES: NowBarSide[] = ["left", "top", "right", "bottom"];
+const NOW_BAR_SIDE_CLASSES = ["LeftSide", "RightSide", "TopSide", "BottomSide"];
+const NOW_BAR_PAGE_SIDE_CLASSES = [
+  "NowBarSide__Left",
+  "NowBarSide__Right",
+  "NowBarSide__Top",
+  "NowBarSide__Bottom",
+];
+
+function isNowBarSide(side: string): side is NowBarSide {
+  return NOW_BAR_SIDES.includes(side as NowBarSide);
+}
+
+function nowBarSideClass(side: NowBarSide) {
+  return `${side[0].toUpperCase()}${side.slice(1)}Side`;
+}
+
+function nowBarPageSideClass(side: NowBarSide) {
+  return `NowBarSide__${side[0].toUpperCase()}${side.slice(1)}`;
+}
+
+function ApplyNowBarSide(side: string) {
+  const NowBar = PageContainer.querySelector(".ContentBox .NowBar");
+  if (!NowBar) return;
+
+  const spicyLyricsPage = PageContainer;
+  if (!spicyLyricsPage) return;
+
+  const nextSide = isNowBarSide(side) ? side : "left";
+  if (nextSide !== side) $nowBarSide.set(nextSide);
+
+  NowBar.classList.remove(...NOW_BAR_SIDE_CLASSES);
+  NowBar.classList.add(nowBarSideClass(nextSide));
+
+  spicyLyricsPage.classList.remove(...NOW_BAR_PAGE_SIDE_CLASSES);
+  spicyLyricsPage.classList.add(nowBarPageSideClass(nextSide));
+}
+
 /* const ActiveMarquees = new Map();
 
 /**
@@ -1439,32 +1479,12 @@ function UpdateNowBar(force = false) {
 
 
 function NowBar_SwapSides() {
-  const NowBar = PageContainer.querySelector(".ContentBox .NowBar");
-  if (!NowBar) return;
-
-  const spicyLyricsPage = PageContainer;
-  if (!spicyLyricsPage) return;
-
   const CurrentSide = $nowBarSide.get();
-  if (CurrentSide === "left") {
-    $nowBarSide.set("right");
-    NowBar.classList.remove("LeftSide");
-    NowBar.classList.add("RightSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Left");
-    spicyLyricsPage.classList.add("NowBarSide__Right");
-  } else if (CurrentSide === "right") {
-    $nowBarSide.set("left");
-    NowBar.classList.remove("RightSide");
-    NowBar.classList.add("LeftSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Right");
-    spicyLyricsPage.classList.add("NowBarSide__Left");
-  } else {
-    $nowBarSide.set("right");
-    NowBar.classList.remove("LeftSide");
-    NowBar.classList.add("RightSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Left");
-    spicyLyricsPage.classList.add("NowBarSide__Right");
-  }
+  const currentIndex = NOW_BAR_SIDES.indexOf(CurrentSide);
+  const nextSide = NOW_BAR_SIDES[(currentIndex + 1) % NOW_BAR_SIDES.length];
+
+  $nowBarSide.set(nextSide);
+  ApplyNowBarSide(nextSide);
 
   setTimeout(() => {
     // console.log("Resizing Lyrics Container");
@@ -1475,30 +1495,7 @@ function NowBar_SwapSides() {
 }
 
 function Session_NowBar_SetSide() {
-  const NowBar = PageContainer.querySelector(".ContentBox .NowBar");
-  if (!NowBar) return;
-
-  const spicyLyricsPage = PageContainer;
-  if (!spicyLyricsPage) return;
-
-  const CurrentSide = $nowBarSide.get();
-  if (CurrentSide === "left") {
-    NowBar.classList.remove("RightSide");
-    NowBar.classList.add("LeftSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Right");
-    spicyLyricsPage.classList.add("NowBarSide__Left");
-  } else if (CurrentSide === "right") {
-    NowBar.classList.remove("LeftSide");
-    NowBar.classList.add("RightSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Left");
-    spicyLyricsPage.classList.add("NowBarSide__Right");
-  } else {
-    $nowBarSide.set("left");
-    NowBar.classList.remove("RightSide");
-    NowBar.classList.add("LeftSide");
-    spicyLyricsPage.classList.remove("NowBarSide__Right");
-    spicyLyricsPage.classList.add("NowBarSide__Left");
-  }
+  ApplyNowBarSide($nowBarSide.get());
   setTimeout(() => {
     // console.log("Resizing Lyrics Container");
     GetCurrentLyricsContainerInstance()?.Resize();

--- a/src/css/ContentBox.css
+++ b/src/css/ContentBox.css
@@ -52,6 +52,11 @@
 
 #SpicyLyricsPage {
   --NowBarWidth: calc(min(30cqw, 52cqh) * 1.1);
+  --NowBarVerticalWidth: min(38cqw, 28cqh);
+  --NowBarVerticalSpacing: 4cqh;
+  --NowBarVerticalContentPadding: calc(
+    var(--NowBarVerticalWidth) + var(--NowBarVerticalSpacing) + 16cqh
+  );
   --NowBarRightSpacing: calc(var(--NowBarWidth) / 4);
   --NowBarLeftSpacing: calc(
     50cqw - var(--NowBarWidth) - var(--NowBarRightSpacing)
@@ -108,6 +113,20 @@
   );
 }
 
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode):has(
+    .NowBar.Active:is(.TopSide, .BottomSide)
+  ) {
+  --LyricsLeftSidePadding: 18cqw;
+  --LyricsRightSidePadding: 15.5cqw;
+}
+
+#SpicyLyricsPage:not(.SpicyRenderer):not(.CompactMode):not(.ForcedCompactMode):has(
+    .NowBar.Active:is(.TopSide, .BottomSide)
+  ) {
+  --LyricsLeftSidePadding: 10cqw;
+  --LyricsRightSidePadding: 8cqw;
+}
+
 #SpicyLyricsPage.CompactMode:has(.NowBar.Active),
 #SpicyLyricsPage.ForcedCompactMode:has(.NowBar.Active) {
   --NowBarLeftSpacing: 0px !important;
@@ -150,6 +169,57 @@
 
 #SpicyLyricsPage .ContentBox .NowBar.RightSide.Active {
   left: calc(100% - var(--NowBarWidth) - var(--NowBarLeftSpacing));
+}
+
+#SpicyLyricsPage .ContentBox .NowBar.TopSide,
+#SpicyLyricsPage .ContentBox .NowBar.BottomSide {
+  left: calc(50cqw - var(--NowBarVerticalWidth) / 2);
+  width: var(--NowBarVerticalWidth);
+  transition: top 0.4s;
+}
+
+#SpicyLyricsPage .ContentBox .NowBar.TopSide {
+  top: calc(
+    (var(--NowBarVerticalWidth) + var(--NowBarVerticalSpacing) + 12cqh) * -1
+  );
+  padding-top: var(--NowBarVerticalSpacing);
+}
+
+#SpicyLyricsPage .ContentBox .NowBar.TopSide.Active {
+  top: 0;
+}
+
+#SpicyLyricsPage .ContentBox .NowBar.BottomSide {
+  top: calc(100cqh + var(--NowBarVerticalSpacing));
+  padding-top: calc(
+    100cqh - var(--NowBarVerticalWidth) - var(--NowBarVerticalSpacing) - 6cqh
+  );
+}
+
+#SpicyLyricsPage .ContentBox .NowBar.BottomSide.Active {
+  top: 0;
+}
+
+#SpicyLyricsPage .ContentBox .NowBar:is(.TopSide, .BottomSide) .Header .Metadata {
+  gap: 0.15cqw;
+  height: 10cqh;
+  margin: 2.5cqw 0 0;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.TopSide
+  .Header
+  .Metadata {
+  margin-top: 0.75cqw;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar:is(.TopSide, .BottomSide)
+  .Header:not(:has(> .Timeline))
+  .Metadata {
+  margin: 2.5cqw 0 0;
 }
 
 #SpicyLyricsPage .ContentBox .NowBar .Header .MediaBox {
@@ -306,6 +376,29 @@
   padding: 0 3cqw 0 2.5cqw;
 }
 
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .Header
+  .Metadata {
+  gap: 0.35cqw;
+}
+
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .Header
+  .Metadata
+  .SongName,
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .Header
+  .Metadata
+  .Artists {
+  line-height: 1.1 !important;
+}
+
 #SpicyLyricsPage .ContentBox .NowBar .Header .Metadata .SongName span.Clickable,
 #SpicyLyricsPage .ContentBox .NowBar .Header .Metadata .Artists span.Clickable {
   cursor: pointer;
@@ -352,6 +445,15 @@
     rgba(0, 0, 0, 0.2) 20%
   );
   padding-right: var(--ContentPadding);
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar:is(.Active.TopSide, .Active.BottomSide)
+  + .LyricsContainer
+  .loaderContainer {
+  --ContentPadding: 0;
+  background: rgba(0, 0, 0, 0.18);
 }
 
 #SpicyLyricsPage:has(.ContentBox.LyricsHidden) {
@@ -880,6 +982,14 @@
   gap: 0.6cqw;
 }
 
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar
+  .Header
+  > .Timeline {
+  padding-bottom: 0.75cqw;
+}
+
 #SpicyLyricsPage .MediaContent .Timeline {
   position: absolute;
   bottom: 0;
@@ -1372,6 +1482,74 @@
   .LyricsNotice {
   padding-right: var(--LyricsLeftSidePadding) !important;
   padding-left: calc(var(--LyricsRightSidePadding) * 1.45) !important;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.TopSide)
+  + .LyricsContainer
+  .LyricsContent
+  .simplebar-content-wrapper
+  .SpicyLyricsScrollContainer,
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar.Active:is(.TopSide)
+  + .LyricsContainer
+  .LyricsContent
+  .LyricsNotice {
+  padding-top: 0 !important;
+  padding-left: var(--LyricsRightSidePadding) !important;
+  padding-right: var(--LyricsRightSidePadding) !important;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.BottomSide)
+  + .LyricsContainer
+  .LyricsContent
+  .simplebar-content-wrapper
+  .SpicyLyricsScrollContainer,
+#SpicyLyricsPage:not(.CompactMode):not(.ForcedCompactMode)
+  .ContentBox
+  .NowBar.Active:is(.BottomSide)
+  + .LyricsContainer
+  .LyricsContent
+  .LyricsNotice {
+  padding-bottom: 0 !important;
+  padding-left: var(--LyricsRightSidePadding) !important;
+  padding-right: var(--LyricsRightSidePadding) !important;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.TopSide)
+  + .LyricsContainer {
+  justify-content: flex-end;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.TopSide)
+  + .LyricsContainer
+  .LyricsContent {
+  height: calc(100% - var(--NowBarVerticalContentPadding));
+  max-height: calc(100% - var(--NowBarVerticalContentPadding));
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.BottomSide)
+  + .LyricsContainer {
+  justify-content: flex-start;
+}
+
+#SpicyLyricsPage
+  .ContentBox
+  .NowBar.Active:is(.BottomSide)
+  + .LyricsContainer
+  .LyricsContent {
+  height: calc(100% - var(--NowBarVerticalContentPadding));
+  max-height: calc(100% - var(--NowBarVerticalContentPadding));
 }
 
 #SpicyLyricsPage .ContentBox .NowBar .Header .MediaBox .Heart {

--- a/src/utils/uiState.ts
+++ b/src/utils/uiState.ts
@@ -48,7 +48,7 @@ function persistAtom<T>(key: string, defaultValue: T) {
 
 // UI state atoms (persisted, not settings-panel entries)
 export const $isNowBarOpen = persistAtom<boolean>("isNowBarOpen", false);
-export const $nowBarSide = persistAtom<"left" | "right">("nowBarSide", "left");
+export const $nowBarSide = persistAtom<"left" | "right" | "top" | "bottom">("nowBarSide", "left");
 export const $forceCompactMode = persistAtom<boolean>("forceCompactMode", false);
 export const $romanization = persistAtom<boolean>("romanization", false);
 export const $fromVersion = persistAtom<string>("fromVersion", "");


### PR DESCRIPTION
Adds proof-of-concept top and bottom NowBar positions.

This expands the existing NowBar side preference from left/right to left/top/right/bottom and makes the existing position button cycle through all four layouts. The goal is to support portrait/narrow displays where artwork above or below the lyrics is more usable than left/right artwork.

Notes:
- Left/right behavior is preserved.
- Top layout is working well in local testing.
- Bottom layout is usable but may need maintainer polish.
- There are still some spacing/style differences around the experimental progress bar and timeline placement.
- Compact mode still forces the existing left-side layout to avoid changing compact/PIP behavior.

I’m opening this as a proof of concept because the main structure is there, but I expect you may want to adjust the final UI/spacing/progress-bar behavior to match the project’s preferred design.