### PR TITLE
Deduplicate Syllable and Line lyrics applyers into shared pipeline

### DIFF
--- a/src/utils/Lyrics/Applyer/Synced/Base.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Base.ts
@@ -1,0 +1,292 @@
+// Shared rendering pipeline for the two synced lyrics types (Syllable & Line).
+// The types differ only in their line shapes and word-building; the container
+// setup, musical interludes, credits, scrolling and virtualization are identical.
+
+import { $lyricsContainerExists } from "../../../../utils/stores.ts";
+import { PageContainer } from "../../../../components/Pages/PageView.ts";
+import { applyStyles, removeAllStyles } from "../../../CSS/Styles.ts";
+import {
+  ClearScrollSimplebar,
+  MountScrollSimplebar,
+  RecalculateScrollSimplebar,
+  ScrollSimplebar,
+} from "../../../Scrolling/Simplebar/ScrollSimplebar.ts";
+import { ConvertTime } from "../../ConvertTime.ts";
+import { ClearLyricsPageContainer } from "../../fetchLyrics.ts";
+import {
+  ClearLyricsContentArrays,
+  getInterludeTimePadding,
+  getLyricsBetweenShow,
+  setRomanizedStatus,
+  type SyllableLead,
+} from "../../lyrics.ts";
+import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer.ts";
+import { initLyricsVirtualizer } from "../../LyricsVirtualizer.ts";
+import { ApplyIsByCommunity } from "../Credits/ApplyIsByCommunity.tsx";
+import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits.ts";
+import { EmitApply, EmitNotApplyed } from "../OnApply.ts";
+import { ApplyLyricsProvider } from "../Credits/ApplyProvider.ts";
+
+/** Structural view of a rendered synced-lyrics line, shared by both types. */
+export interface SyncedLyricsLine {
+  HTMLElement: HTMLElement;
+  StartTime: number;
+  EndTime: number;
+  TotalTime?: number;
+  DotLine?: boolean;
+  BGLine?: boolean;
+  Syllables?: { Lead: SyllableLead[] };
+}
+
+/** Base shape of synced-lyrics payloads. `Content` is defined per type. */
+export interface SyncedLyricsData {
+  Type: string;
+  StartTime: number;
+  SongWriters?: string[];
+  source?: "spt" | "spl" | "aml";
+  classes?: string;
+  styles?: Record<string, string>;
+}
+
+export interface SyncedLineContent {
+  OppositeAligned?: boolean;
+}
+
+/** The differences between the Syllable and Line renderers. */
+export interface SyncedApplyMode<TLine extends SyncedLineContent> {
+  typeName: "Syllable" | "Line";
+  linesTarget: { Lines: SyncedLyricsLine[] };
+  onRegularLinePushed: () => void;
+  onMusicalLinePushed: () => void;
+  extendLineEndTime: () => boolean;
+  getLineStartTime: (line: TLine) => number;
+  getLineEndTime: (line: TLine) => number;
+  buildLineContent: (params: {
+    line: TLine;
+    lineElem: HTMLElement;
+    useRomanized: boolean;
+    lines: SyncedLyricsLine[];
+    lineElements: HTMLElement[];
+  }) => void;
+  hasRtlLines: (content: TLine[]) => boolean;
+}
+
+/** Push a word/dot into the Syllables.Lead of the most recently pushed line. */
+export function PushSyncedWord(lines: SyncedLyricsLine[], word: SyllableLead): void {
+  const currentLine = lines[lines.length - 1];
+  if (currentLine?.Syllables?.Lead) {
+    currentLine.Syllables.Lead.push(word);
+  } else {
+    console.warn("Syllables.Lead is undefined for the current line");
+  }
+}
+
+/**
+ * Build a musical interlude line (the "• • •" dots) and register its three dots.
+ * Used both for the leading interlude before the first line and for gaps
+ * between lines.
+ */
+export function CreateMusicalLine<TLine extends SyncedLineContent>(params: {
+  lineStartTime: number;
+  lineEndTime: number;
+  oppositeAligned: boolean | undefined;
+  lineElements: HTMLElement[];
+  lines: SyncedLyricsLine[];
+  mode: SyncedApplyMode<TLine>;
+}): void {
+  const { lineStartTime, lineEndTime, oppositeAligned, lineElements, lines, mode } = params;
+
+  const musicalLine = document.createElement("div");
+  musicalLine.classList.add("line");
+  musicalLine.classList.add("musical-line");
+
+  lines.push({
+    HTMLElement: musicalLine,
+    StartTime: lineStartTime,
+    EndTime: lineEndTime,
+    TotalTime: lineEndTime - lineStartTime,
+    DotLine: true,
+  });
+
+  mode.onMusicalLinePushed();
+
+  if (oppositeAligned) {
+    musicalLine.classList.add("OppositeAligned");
+  }
+
+  const dotGroup = document.createElement("div");
+  dotGroup.classList.add("dotGroup");
+
+  const totalTime = lineEndTime - lineStartTime;
+  const baseDotTime = totalTime / 3;
+  const dotPadding = getInterludeTimePadding() / 3;
+  const dot1EndTime = Math.max(lineStartTime, lineStartTime + baseDotTime + dotPadding);
+  const dot2EndTime = Math.max(dot1EndTime, lineStartTime + baseDotTime * 2 + dotPadding * 2);
+  const dot3EndTime = Math.max(dot2EndTime, lineStartTime + totalTime + getInterludeTimePadding());
+
+  const dotEndTimes = [dot1EndTime, dot2EndTime, dot3EndTime];
+  let prevEndTime = lineStartTime;
+
+  for (const endTime of dotEndTimes) {
+    const dot = document.createElement("span");
+    dot.classList.add("word");
+    dot.classList.add("dot");
+    dot.textContent = "•";
+
+    PushSyncedWord(lines, {
+      HTMLElement: dot,
+      StartTime: prevEndTime,
+      EndTime: endTime,
+      TotalTime: endTime - prevEndTime,
+      Dot: true,
+    });
+
+    dotGroup.appendChild(dot);
+    prevEndTime = endTime;
+  }
+
+  musicalLine.appendChild(dotGroup);
+  lineElements.push(musicalLine);
+}
+
+/**
+ * Shared pipeline for applying synced lyrics.
+ * @param data - the lyrics payload (Syllable or Line shaped)
+ * @param useRomanized - whether to prefer transliterated text
+ * @param mode - the per-type differences
+ */
+export function ApplySyncedLyrics<TLine extends SyncedLineContent>(
+  data: SyncedLyricsData & { Content: TLine[] },
+  useRomanized: boolean,
+  mode: SyncedApplyMode<TLine>
+): void {
+  if (!$lyricsContainerExists.get()) return;
+  EmitNotApplyed();
+
+  DestroyAllLyricsContainers();
+
+  const LyricsContainerParent = PageContainer?.querySelector<HTMLElement>(
+    ".LyricsContainer .LyricsContent"
+  );
+  const LyricsContainerInstance = CreateLyricsContainer();
+  const LyricsContainer = LyricsContainerInstance.Container;
+
+  if (!LyricsContainer) {
+    console.error("LyricsContainer not found");
+    return;
+  }
+
+  const hasOppositeAligned = data.Content.some((item) => item.OppositeAligned === true);
+  LyricsContainer.classList.toggle("HasDuetLines", hasOppositeAligned);
+  LyricsContainer.classList.toggle("HasRtlLines", mode.hasRtlLines(data.Content));
+
+  LyricsContainer.setAttribute("data-lyrics-type", mode.typeName);
+
+  ClearLyricsContentArrays();
+  ClearScrollSimplebar();
+  ClearLyricsPageContainer();
+
+  // Resolve the target array after the clears: ClearLyricsContentArrays
+  // replaces the arrays with fresh ones.
+  const lines = mode.linesTarget.Lines;
+
+  const virtualContainer = document.createElement("div");
+  virtualContainer.classList.add("VirtualLyricsContainer");
+  LyricsContainer.appendChild(virtualContainer);
+
+  const lineElements: HTMLElement[] = [];
+
+  if (data.StartTime >= getLyricsBetweenShow()) {
+    CreateMusicalLine({
+      lineStartTime: 0,
+      lineEndTime: ConvertTime(data.StartTime),
+      oppositeAligned: data.Content[0]?.OppositeAligned,
+      lineElements,
+      lines,
+      mode,
+    });
+  }
+
+  data.Content.forEach((line, index, arr) => {
+    const lineElem = document.createElement("div");
+    lineElem.classList.add("line");
+
+    const lineStartTime = mode.getLineStartTime(line);
+    const lineEndTimeRaw = mode.getLineEndTime(line);
+    const nextLineStartTime = arr[index + 1] ? mode.getLineStartTime(arr[index + 1]) : 0;
+
+    const lineEndTime = mode.extendLineEndTime()
+      ? nextLineStartTime === 0
+        ? lineEndTimeRaw
+        : nextLineStartTime - lineEndTimeRaw < getLyricsBetweenShow() &&
+            nextLineStartTime > lineEndTimeRaw
+          ? nextLineStartTime
+          : lineEndTimeRaw
+      : lineEndTimeRaw;
+
+    lines.push({
+      HTMLElement: lineElem,
+      StartTime: ConvertTime(lineStartTime),
+      EndTime: ConvertTime(lineEndTime),
+      TotalTime: ConvertTime(lineEndTime) - ConvertTime(lineStartTime),
+    });
+
+    mode.onRegularLinePushed();
+
+    if (line.OppositeAligned) {
+      lineElem.classList.add("OppositeAligned");
+    }
+
+    lineElements.push(lineElem);
+
+    mode.buildLineContent({ line, lineElem, useRomanized, lines, lineElements });
+
+    const nextLine = arr[index + 1];
+    if (nextLine && mode.getLineStartTime(nextLine) - lineEndTimeRaw >= getLyricsBetweenShow()) {
+      CreateMusicalLine({
+        lineStartTime: ConvertTime(lineEndTimeRaw),
+        lineEndTime: ConvertTime(mode.getLineStartTime(nextLine)),
+        oppositeAligned: nextLine.OppositeAligned,
+        lineElements,
+        lines,
+        mode,
+      });
+    }
+  });
+
+  ApplyLyricsCredits(data, LyricsContainer);
+  ApplyLyricsProvider(data, LyricsContainer);
+  ApplyIsByCommunity(data, LyricsContainer);
+
+  if (LyricsContainerParent) {
+    LyricsContainerInstance.Append(LyricsContainerParent);
+  }
+
+  if (ScrollSimplebar) RecalculateScrollSimplebar();
+  else MountScrollSimplebar();
+
+  const scrollEl = ScrollSimplebar?.getScrollElement() as HTMLElement | undefined;
+  if (scrollEl) initLyricsVirtualizer(scrollEl, virtualContainer, lineElements);
+
+  const LyricsStylingContainer = PageContainer?.querySelector<HTMLElement>(
+    ".LyricsContainer .LyricsContent .simplebar-content"
+  );
+
+  if (LyricsStylingContainer) {
+    removeAllStyles(LyricsStylingContainer);
+
+    if (data.classes) {
+      LyricsStylingContainer.className = data.classes;
+    }
+
+    if (data.styles) {
+      applyStyles(LyricsStylingContainer, data.styles);
+    }
+  } else {
+    console.warn("LyricsStylingContainer not found");
+  }
+
+  EmitApply(data.Type, data.Content);
+
+  setRomanizedStatus(useRomanized);
+}

--- a/src/utils/Lyrics/Applyer/Synced/Line.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Line.ts
@@ -1,32 +1,8 @@
-import { $lyricsContainerExists, $simpleLyricsMode } from "../../../../utils/stores.ts";
-import { PageContainer } from "../../../../components/Pages/PageView.ts";
-import { applyStyles, removeAllStyles } from "../../../CSS/Styles.ts";
-import {
-  ClearScrollSimplebar,
-  MountScrollSimplebar,
-  RecalculateScrollSimplebar,
-  ScrollSimplebar,
-} from "../../../Scrolling/Simplebar/ScrollSimplebar.ts";
-import { ConvertTime } from "../../ConvertTime.ts";
-import { ClearLyricsPageContainer } from "../../fetchLyrics.ts";
+import { $simpleLyricsMode } from "../../../../utils/stores.ts";
 import isRtl from "../../isRtl.ts";
-import {
-  ClearLyricsContentArrays,
-  LINE_SYNCED_CurrentLineLyricsObject,
-  LyricsObject,
-  SetWordArrayInCurentLine_LINE_SYNCED,
-  getInterludeTimePadding,
-  getLyricsBetweenShow,
-  setRomanizedStatus,
-} from "../../lyrics.ts";
-import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer.ts";
-import { initLyricsVirtualizer } from "../../LyricsVirtualizer.ts";
-import { ApplyIsByCommunity } from "../Credits/ApplyIsByCommunity.tsx";
-import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits.ts";
-import { EmitApply, EmitNotApplyed } from "../OnApply.ts";
-import { ApplyLyricsProvider } from "../Credits/ApplyProvider.ts";
+import { LyricsObject, SetWordArrayInCurentLine_LINE_SYNCED } from "../../lyrics.ts";
+import { ApplySyncedLyrics, type SyncedApplyMode } from "./Base.ts";
 
-// Define the data structure for lyrics
 interface LyricsLineData {
   Text: string;
   StartTime: number;
@@ -35,7 +11,7 @@ interface LyricsLineData {
   OppositeAligned?: boolean;
 }
 
-interface LyricsData {
+interface LineLyricsData {
   Type: string;
   Content: LyricsLineData[];
   StartTime: number;
@@ -45,290 +21,26 @@ interface LyricsData {
   styles?: Record<string, string>;
 }
 
-export function ApplyLineLyrics(data: LyricsData, UseRomanized: boolean = false): void {
-  if (!$lyricsContainerExists.get()) return;
-  EmitNotApplyed();
-
-  DestroyAllLyricsContainers();
-
-  const LyricsContainerParent = PageContainer?.querySelector<HTMLElement>(
-    ".LyricsContainer .LyricsContent"
-  );
-  const LyricsContainerInstance = CreateLyricsContainer();
-  const LyricsContainer = LyricsContainerInstance.Container;
-
-  // Check if LyricsContainer exists
-  if (!LyricsContainer) {
-    console.error("LyricsContainer not found");
-    return;
-  }
-
-  const hasOppositeAligned = data.Content.some(item => item.OppositeAligned === true);
-  LyricsContainer.classList.toggle("HasDuetLines", hasOppositeAligned);
-  const hasRtlLines = data.Content.some(line => isRtl(line.Text));
-  LyricsContainer.classList.toggle("HasRtlLines", hasRtlLines);
-
-  LyricsContainer.setAttribute("data-lyrics-type", "Line");
-
-  ClearLyricsContentArrays();
-
-  ClearScrollSimplebar();
-
-  ClearLyricsPageContainer();
-
-  const virtualContainer = document.createElement("div");
-  virtualContainer.classList.add("VirtualLyricsContainer");
-  LyricsContainer.appendChild(virtualContainer);
-
-  const lineElements: HTMLElement[] = [];
-
-  if (data.StartTime >= getLyricsBetweenShow()) {
-    const musicalLine = document.createElement("div");
-    musicalLine.classList.add("line");
-    musicalLine.classList.add("musical-line");
-
-    LyricsObject.Types.Line.Lines.push({
-      HTMLElement: musicalLine,
-      StartTime: 0,
-      EndTime: ConvertTime(data.StartTime),
-      TotalTime: ConvertTime(data.StartTime),
-      DotLine: true,
-    });
-
-    SetWordArrayInCurentLine_LINE_SYNCED();
-
-    if (data.Content[0].OppositeAligned) {
-      musicalLine.classList.add("OppositeAligned");
-    }
-
-    const dotGroup = document.createElement("div");
-    dotGroup.classList.add("dotGroup");
-
-    const musicalDots1 = document.createElement("span");
-    const musicalDots2 = document.createElement("span");
-    const musicalDots3 = document.createElement("span");
-
-    const totalTime = ConvertTime(data.StartTime);
-    const baseDotTime = totalTime / 3;
-    const dotPadding = getInterludeTimePadding() / 3;
-    const dot1EndTime = Math.max(0, baseDotTime + dotPadding);
-    const dot2EndTime = Math.max(dot1EndTime, baseDotTime * 2 + dotPadding * 2);
-    const dot3EndTime = Math.max(dot2EndTime, totalTime + getInterludeTimePadding());
-
-    musicalDots1.classList.add("word");
-    musicalDots1.classList.add("dot");
-    musicalDots1.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots1,
-        StartTime: 0,
-        EndTime: dot1EndTime,
-        TotalTime: dot1EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for LINE_SYNCED_CurrentLineLyricsObject");
-    }
-
-    musicalDots2.classList.add("word");
-    musicalDots2.classList.add("dot");
-    musicalDots2.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots2,
-        StartTime: dot1EndTime,
-        EndTime: dot2EndTime,
-        TotalTime: dot2EndTime - dot1EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for LINE_SYNCED_CurrentLineLyricsObject");
-    }
-
-    musicalDots3.classList.add("word");
-    musicalDots3.classList.add("dot");
-    musicalDots3.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots3,
-        StartTime: dot2EndTime,
-        EndTime: dot3EndTime,
-        TotalTime: dot3EndTime - dot2EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for LINE_SYNCED_CurrentLineLyricsObject");
-    }
-
-    dotGroup.appendChild(musicalDots1);
-    dotGroup.appendChild(musicalDots2);
-    dotGroup.appendChild(musicalDots3);
-
-    musicalLine.appendChild(dotGroup);
-    lineElements.push(musicalLine);
-  }
-
-  data.Content.forEach((line, index, arr) => {
-    const lineElem = document.createElement("div");
+const LineMode: SyncedApplyMode<LyricsLineData> = {
+  typeName: "Line",
+  linesTarget: LyricsObject.Types.Line,
+  // LINE_SYNCED lines carry no word arrays — only musical lines do.
+  onRegularLinePushed: () => {},
+  onMusicalLinePushed: SetWordArrayInCurentLine_LINE_SYNCED,
+  extendLineEndTime: () => $simpleLyricsMode.get(),
+  getLineStartTime: (line) => line.StartTime,
+  getLineEndTime: (line) => line.EndTime,
+  buildLineContent: ({ line, lineElem, useRomanized }) => {
     lineElem.textContent =
-      UseRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text;
-    lineElem.classList.add("line");
+      useRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text;
 
     if (isRtl(line.Text) && !lineElem.classList.contains("rtl")) {
       lineElem.classList.add("rtl");
     }
+  },
+  hasRtlLines: (content) => content.some((line) => isRtl(line.Text)),
+};
 
-    const nextLineStartTime = arr[index + 1]?.StartTime ?? 0;
-
-    const lineEndTimeAndNextLineStartTimeDistance =
-      nextLineStartTime !== 0 ? nextLineStartTime - line.EndTime : 0;
-
-    const lineEndTime = $simpleLyricsMode.get()
-      ? nextLineStartTime === 0
-        ? line.EndTime
-        : lineEndTimeAndNextLineStartTimeDistance < getLyricsBetweenShow() &&
-            nextLineStartTime > line.EndTime
-          ? nextLineStartTime
-          : line.EndTime
-      : line.EndTime;
-
-    LyricsObject.Types.Line.Lines.push({
-      HTMLElement: lineElem,
-      StartTime: ConvertTime(line.StartTime),
-      EndTime: ConvertTime(lineEndTime),
-      TotalTime: ConvertTime(lineEndTime) - ConvertTime(line.StartTime),
-    });
-
-    if (line.OppositeAligned) {
-      lineElem.classList.add("OppositeAligned");
-    }
-
-    lineElements.push(lineElem);
-    if (arr[index + 1] && arr[index + 1].StartTime - line.EndTime >= getLyricsBetweenShow()) {
-      const musicalLine = document.createElement("div");
-      musicalLine.classList.add("line");
-      musicalLine.classList.add("musical-line");
-
-      LyricsObject.Types.Line.Lines.push({
-        HTMLElement: musicalLine,
-        StartTime: ConvertTime(line.EndTime),
-        EndTime: ConvertTime(arr[index + 1].StartTime),
-        TotalTime:
-          ConvertTime(arr[index + 1].StartTime) - ConvertTime(line.EndTime),
-        DotLine: true,
-      });
-
-      SetWordArrayInCurentLine_LINE_SYNCED();
-
-      if (arr[index + 1].OppositeAligned) {
-        musicalLine.classList.add("OppositeAligned");
-      }
-
-      const dotGroup = document.createElement("div");
-      dotGroup.classList.add("dotGroup");
-
-      const musicalDots1 = document.createElement("span");
-      const musicalDots2 = document.createElement("span");
-      const musicalDots3 = document.createElement("span");
-
-      const gapStartTime = ConvertTime(line.EndTime);
-      const totalTime = ConvertTime(arr[index + 1].StartTime) - gapStartTime;
-      const baseDotTime = totalTime / 3;
-      const dotPadding = getInterludeTimePadding() / 3;
-      const dot1EndTime = Math.max(gapStartTime, gapStartTime + baseDotTime + dotPadding);
-      const dot2EndTime = Math.max(dot1EndTime, gapStartTime + baseDotTime * 2 + dotPadding * 2);
-      const dot3EndTime = Math.max(dot2EndTime, gapStartTime + totalTime + getInterludeTimePadding());
-
-      musicalDots1.classList.add("word");
-      musicalDots1.classList.add("dot");
-      musicalDots1.textContent = "•";
-
-      // Check if Syllables.Lead exists
-      if (LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject]?.Syllables?.Lead) {
-        LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-          HTMLElement: musicalDots1,
-          StartTime: gapStartTime,
-          EndTime: dot1EndTime,
-          TotalTime: dot1EndTime - gapStartTime,
-          Dot: true,
-        });
-      } else {
-        console.warn("Syllables.Lead is undefined for LINE_SYNCED_CurrentLineLyricsObject");
-      }
-
-      musicalDots2.classList.add("word");
-      musicalDots2.classList.add("dot");
-      musicalDots2.textContent = "•";
-
-      LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots2,
-        StartTime: dot1EndTime,
-        EndTime: dot2EndTime,
-        TotalTime: dot2EndTime - dot1EndTime,
-        Dot: true,
-      });
-
-      musicalDots3.classList.add("word");
-      musicalDots3.classList.add("dot");
-      musicalDots3.textContent = "•";
-
-      LyricsObject.Types.Line.Lines[LINE_SYNCED_CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots3,
-        StartTime: dot2EndTime,
-        EndTime: dot3EndTime,
-        TotalTime: dot3EndTime - dot2EndTime,
-        Dot: true,
-      });
-
-      dotGroup.appendChild(musicalDots1);
-      dotGroup.appendChild(musicalDots2);
-      dotGroup.appendChild(musicalDots3);
-
-      musicalLine.appendChild(dotGroup);
-      lineElements.push(musicalLine);
-    }
-  });
-
-  ApplyLyricsCredits(data, LyricsContainer);
-  ApplyLyricsProvider(data, LyricsContainer);
-  ApplyIsByCommunity(data, LyricsContainer);
-
-  if (LyricsContainerParent) {
-    LyricsContainerInstance.Append(LyricsContainerParent);
-  }
-
-  if (ScrollSimplebar) RecalculateScrollSimplebar();
-  else MountScrollSimplebar();
-
-  const scrollEl = ScrollSimplebar?.getScrollElement() as HTMLElement | undefined;
-  if (scrollEl) initLyricsVirtualizer(scrollEl, virtualContainer, lineElements);
-
-  const LyricsStylingContainer = PageContainer?.querySelector<HTMLElement>(
-    ".LyricsContainer .LyricsContent .simplebar-content"
-  );
-
-  // Check if LyricsStylingContainer exists
-  if (LyricsStylingContainer) {
-    removeAllStyles(LyricsStylingContainer);
-
-    if (data.classes) {
-      LyricsStylingContainer.className = data.classes;
-    }
-
-    if (data.styles) {
-      applyStyles(LyricsStylingContainer, data.styles);
-    }
-  } else {
-    console.warn("LyricsStylingContainer not found");
-  }
-
-  EmitApply(data.Type, data.Content);
-
-  setRomanizedStatus(UseRomanized);
+export function ApplyLineLyrics(data: LineLyricsData, UseRomanized: boolean = false): void {
+  ApplySyncedLyrics(data, UseRomanized, LineMode);
 }

--- a/src/utils/Lyrics/Applyer/Synced/Syllable.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Syllable.ts
@@ -1,36 +1,18 @@
-import { $lyricsContainerExists, $minimalLyricsMode, $simpleLyricsMode } from "../../../../utils/stores.ts";
-import { PageContainer } from "../../../../components/Pages/PageView.ts";
-import { applyStyles, removeAllStyles } from "../../../CSS/Styles.ts";
-import {
-  ClearScrollSimplebar,
-  MountScrollSimplebar,
-  RecalculateScrollSimplebar,
-  ScrollSimplebar,
-} from "../../../Scrolling/Simplebar/ScrollSimplebar.ts";
+import { $minimalLyricsMode, $simpleLyricsMode } from "../../../../utils/stores.ts";
 import { IdleEmphasisLyricsScale, IdleLyricsScale } from "../../Animator/Shared.ts";
 import { ConvertTime } from "../../ConvertTime.ts";
-import { ClearLyricsPageContainer } from "../../fetchLyrics.ts";
 import isRtl from "../../isRtl.ts";
-import {
-  ClearLyricsContentArrays,
-  CurrentLineLyricsObject,
-  LyricsObject,
-  SetWordArrayInCurentLine,
-  getInterludeTimePadding,
-  getLyricsBetweenShow,
-  setRomanizedStatus,
-} from "../../lyrics.ts";
-import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer.ts";
-import { initLyricsVirtualizer } from "../../LyricsVirtualizer.ts";
-import { ApplyIsByCommunity } from "../Credits/ApplyIsByCommunity.tsx";
-import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits.ts";
-import { EmitApply, EmitNotApplyed } from "../OnApply.ts";
+import { LyricsObject, SetWordArrayInCurentLine } from "../../lyrics.ts";
 import Emphasize from "../Utils/Emphasize.ts";
 import { IsLetterCapable } from "../Utils/IsLetterCapable.ts";
-import { ApplyLyricsProvider } from "../Credits/ApplyProvider.ts";
+import {
+  ApplySyncedLyrics,
+  PushSyncedWord,
+  type SyncedApplyMode,
+  type SyncedLyricsLine,
+} from "./Base.ts";
 
-// Define the data structure for syllable lyrics
-interface SyllableData {
+interface SyllableWordData {
   Text: string;
   TransliteratedText?: string;
   StartTime: number;
@@ -38,27 +20,27 @@ interface SyllableData {
   IsPartOfWord?: boolean;
 }
 
-interface LeadData {
+interface SyllableLeadData {
   StartTime: number;
   EndTime: number;
-  Syllables: SyllableData[];
+  Syllables: SyllableWordData[];
 }
 
-interface BackgroundData {
+interface SyllableBackgroundData {
   StartTime: number;
   EndTime: number;
-  Syllables: SyllableData[];
+  Syllables: SyllableWordData[];
 }
 
-interface LineData {
-  Lead: LeadData;
-  Background?: BackgroundData[];
+interface SyllableLineData {
+  Lead: SyllableLeadData;
+  Background?: SyllableBackgroundData[];
   OppositeAligned?: boolean;
 }
 
-interface LyricsData {
+interface SyllableLyricsData {
   Type: string;
-  Content: LineData[];
+  Content: SyllableLineData[];
   StartTime: number;
   SongWriters?: string[];
   source?: "spt" | "spl" | "aml";
@@ -66,501 +48,216 @@ interface LyricsData {
   styles?: Record<string, string>;
 }
 
-export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = false): void {
-  if (!$lyricsContainerExists.get()) return;
-  EmitNotApplyed();
+/**
+ * Build a single word element (lead or background) and register it in the
+ * current line's Syllables.Lead when it isn't a letter-capable word (letter
+ * words are registered by Emphasize instead).
+ */
+function BuildSyllableWord(params: {
+  wordData: SyllableWordData;
+  isLast: boolean;
+  isBackground: boolean;
+  useRomanized: boolean;
+  lines: SyncedLyricsLine[];
+}): HTMLElement {
+  const { wordData, isLast, isBackground, useRomanized, lines } = params;
 
-  DestroyAllLyricsContainers();
-  const LyricsContainerParent = PageContainer?.querySelector<HTMLElement>(
-    ".LyricsContainer .LyricsContent"
-  );
-  const LyricsContainerInstance = CreateLyricsContainer();
-  const LyricsContainer = LyricsContainerInstance.Container;
+  let word = document.createElement("span");
 
-  // Check if LyricsContainer exists
-  if (!LyricsContainer) {
-    console.error("LyricsContainer not found");
-    return;
+  const wordText =
+    useRomanized && wordData.TransliteratedText !== undefined
+      ? wordData.TransliteratedText
+      : wordData.Text;
+
+  const totalDuration = ConvertTime(wordData.EndTime) - ConvertTime(wordData.StartTime);
+  const letterLength = wordText.split("").length;
+
+  const ifLetterCapable = IsLetterCapable(letterLength, totalDuration) && !isRtl(wordText);
+
+  if (ifLetterCapable) {
+    word = document.createElement("div");
+    const letters = wordText.split(""); // Split word into individual letters
+
+    Emphasize(letters, word, wordData, isBackground);
+
+    if (isLast) {
+      word.classList.add("LastWordInLine");
+    } else if (wordData.IsPartOfWord) {
+      word.classList.add("PartOfWord");
+    }
+
+    if (!$simpleLyricsMode.get()) {
+      word.style.setProperty("--text-shadow-opacity", `0%`);
+      word.style.setProperty("--text-shadow-blur-radius", `4px`);
+      word.style.scale = IdleEmphasisLyricsScale.toString();
+      word.style.transform = `translateY(calc(${
+        isBackground ? "var(--font-size)" : "var(--DefaultLyricsSize)"
+      } * 0.02))`;
+    }
+  } else {
+    word.textContent = wordText;
+
+    if (!$simpleLyricsMode.get()) {
+      word.style.setProperty("--gradient-position", isBackground ? `0%` : `-20%`);
+      word.style.setProperty("--text-shadow-opacity", `0%`);
+      word.style.setProperty("--text-shadow-blur-radius", `4px`);
+      word.style.scale = IdleLyricsScale.toString();
+      word.style.transform = `translateY(calc(${
+        isBackground ? "var(--font-size)" : "var(--DefaultLyricsSize)"
+      } * 0.01))`;
+    }
+
+    word.classList.add("word");
+
+    if (isBackground) {
+      word.classList.add("bg-word");
+    }
+
+    if (isLast) {
+      word.classList.add("LastWordInLine");
+    } else if (wordData.IsPartOfWord) {
+      word.classList.add("PartOfWord");
+    }
+
+    PushSyncedWord(lines, {
+      HTMLElement: word,
+      StartTime: ConvertTime(wordData.StartTime),
+      EndTime: ConvertTime(wordData.EndTime),
+      TotalTime: totalDuration,
+      ...(isBackground ? { BGWord: true } : {}),
+    });
   }
 
-  const hasOppositeAligned = data.Content.some(item => item.OppositeAligned === true);
-  LyricsContainer.classList.toggle("HasDuetLines", hasOppositeAligned);
-  const hasRtlLines = data.Content.some(line =>
-    line.Lead.Syllables.some(syllable => isRtl(syllable.Text)) ||
-    line.Background?.some(bg => bg.Syllables.some(syllable => isRtl(syllable.Text))) === true
-  );
-  LyricsContainer.classList.toggle("HasRtlLines", hasRtlLines);
+  return word;
+}
 
-  LyricsContainer.setAttribute("data-lyrics-type", "Syllable");
-
-  ClearLyricsContentArrays();
-  ClearScrollSimplebar();
-
-  ClearLyricsPageContainer();
-
-  const virtualContainer = document.createElement("div");
-  virtualContainer.classList.add("VirtualLyricsContainer");
-  LyricsContainer.appendChild(virtualContainer);
-
-  const lineElements: HTMLElement[] = [];
-
-  if (data.StartTime >= getLyricsBetweenShow()) {
-    const musicalLine = document.createElement("div");
-    musicalLine.classList.add("line");
-    musicalLine.classList.add("musical-line");
-    LyricsObject.Types.Syllable.Lines.push({
-      HTMLElement: musicalLine,
-      StartTime: 0,
-      EndTime: ConvertTime(data.StartTime),
-      TotalTime: ConvertTime(data.StartTime),
-      DotLine: true,
-    });
-
-    SetWordArrayInCurentLine();
-
-    if (data.Content[0].OppositeAligned) {
-      musicalLine.classList.add("OppositeAligned");
+function AppendWordToLine(
+  lineElem: HTMLElement,
+  word: HTMLElement,
+  isPartOfWord: boolean,
+  prevIsPartOfWord: boolean,
+  currentWordGroup: HTMLSpanElement | null
+): HTMLSpanElement | null {
+  if (isPartOfWord || (prevIsPartOfWord && currentWordGroup)) {
+    if (!currentWordGroup) {
+      const group = document.createElement("span");
+      group.classList.add("word-group");
+      lineElem.appendChild(group);
+      currentWordGroup = group;
     }
 
-    const dotGroup = document.createElement("div");
-    dotGroup.classList.add("dotGroup");
+    currentWordGroup.appendChild(word);
 
-    const musicalDots1 = document.createElement("span");
-    const musicalDots2 = document.createElement("span");
-    const musicalDots3 = document.createElement("span");
-
-    const totalTime = ConvertTime(data.StartTime);
-    const baseDotTime = totalTime / 3;
-    const dotPadding = getInterludeTimePadding() / 3;
-    const dot1EndTime = Math.max(0, baseDotTime + dotPadding);
-    const dot2EndTime = Math.max(dot1EndTime, baseDotTime * 2 + dotPadding * 2);
-    const dot3EndTime = Math.max(dot2EndTime, totalTime + getInterludeTimePadding());
-
-    musicalDots1.classList.add("word");
-    musicalDots1.classList.add("dot");
-    musicalDots1.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots1,
-        StartTime: 0,
-        EndTime: dot1EndTime,
-        TotalTime: dot1EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
+    if (!isPartOfWord && prevIsPartOfWord) {
+      currentWordGroup = null;
     }
-
-    musicalDots2.classList.add("word");
-    musicalDots2.classList.add("dot");
-    musicalDots2.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots2,
-        StartTime: dot1EndTime,
-        EndTime: dot2EndTime,
-        TotalTime: dot2EndTime - dot1EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-    }
-
-    musicalDots3.classList.add("word");
-    musicalDots3.classList.add("dot");
-    musicalDots3.textContent = "•";
-
-    // Check if Syllables.Lead exists
-    if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-      LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-        HTMLElement: musicalDots3,
-        StartTime: dot2EndTime,
-        EndTime: dot3EndTime,
-        TotalTime: dot3EndTime - dot2EndTime,
-        Dot: true,
-      });
-    } else {
-      console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-    }
-
-    dotGroup.appendChild(musicalDots1);
-    dotGroup.appendChild(musicalDots2);
-    dotGroup.appendChild(musicalDots3);
-
-    musicalLine.appendChild(dotGroup);
-    lineElements.push(musicalLine);
+  } else {
+    currentWordGroup = null;
+    lineElem.appendChild(word);
   }
-  data.Content.forEach((line, index, arr) => {
-    const lineElem = document.createElement("div");
-    lineElem.classList.add("line");
 
-    const nextLineStartTime = arr[index + 1]?.Lead.StartTime ?? 0;
+  return currentWordGroup;
+}
 
-    const lineEndTimeAndNextLineStartTimeDistance =
-      nextLineStartTime !== 0 ? nextLineStartTime - line.Lead.EndTime : 0;
+function BuildSyllableLineContent(params: {
+  line: SyllableLineData;
+  lineElem: HTMLElement;
+  useRomanized: boolean;
+  lines: SyncedLyricsLine[];
+  lineElements: HTMLElement[];
+}): void {
+  const { line, lineElem, useRomanized, lines, lineElements } = params;
 
-    const lineEndTime =
-      $minimalLyricsMode.get()
-        ? nextLineStartTime === 0
-          ? line.Lead.EndTime
-          : lineEndTimeAndNextLineStartTimeDistance < getLyricsBetweenShow() &&
-              nextLineStartTime > line.Lead.EndTime
-            ? nextLineStartTime
-            : line.Lead.EndTime
-        : line.Lead.EndTime;
+  let currentWordGroup: HTMLSpanElement | null = null;
 
-    LyricsObject.Types.Syllable.Lines.push({
-      HTMLElement: lineElem,
-      StartTime: ConvertTime(line.Lead.StartTime),
-      EndTime: ConvertTime(lineEndTime),
-      TotalTime: ConvertTime(lineEndTime) - ConvertTime(line.Lead.StartTime),
-    });
-
-    SetWordArrayInCurentLine();
-
-    if (line.OppositeAligned) {
-      lineElem.classList.add("OppositeAligned");
+  line.Lead.Syllables.forEach((lead, iL, aL) => {
+    if (isRtl(lead.Text) && !lineElem.classList.contains("rtl")) {
+      lineElem.classList.add("rtl");
     }
 
-    lineElements.push(lineElem);
-
-    let currentWordGroup: HTMLSpanElement | null = null;
-
-    line.Lead.Syllables.forEach((lead, iL, aL) => {
-      let word = document.createElement("span");
-
-      if (isRtl(lead.Text) && !lineElem.classList.contains("rtl")) {
-        lineElem.classList.add("rtl");
-      }
-
-      const totalDuration = ConvertTime(lead.EndTime) - ConvertTime(lead.StartTime);
-
-      const letterLength = (
-        UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text
-      ).split("").length;
-
-      const IfLetterCapable = IsLetterCapable(letterLength, totalDuration) && !isRtl(UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text);
-
-      if (IfLetterCapable) {
-        word = document.createElement("div");
-        const letters = (
-          UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text
-        ).split(""); // Split word into individual letters
-
-        Emphasize(letters, word, lead);
-
-        iL === aL.length - 1
-          ? word.classList.add("LastWordInLine")
-          : lead.IsPartOfWord
-            ? word.classList.add("PartOfWord")
-            : null;
-
-        if (!$simpleLyricsMode.get()) {
-          word.style.setProperty("--text-shadow-opacity", `0%`);
-          word.style.setProperty("--text-shadow-blur-radius", `4px`);
-          word.style.scale = IdleEmphasisLyricsScale.toString();
-          word.style.transform = `translateY(calc(var(--DefaultLyricsSize) * 0.02))`;
-        }
-      } else {
-        word.textContent =
-          UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text;
-
-        if (!$simpleLyricsMode.get()) {
-          word.style.setProperty("--gradient-position", `-20%`);
-          word.style.setProperty("--text-shadow-opacity", `0%`);
-          word.style.setProperty("--text-shadow-blur-radius", `4px`);
-          word.style.scale = IdleLyricsScale.toString();
-          word.style.transform = `translateY(calc(var(--DefaultLyricsSize) * 0.01))`;
-        }
-
-        word.classList.add("word");
-
-        iL === aL.length - 1
-          ? word.classList.add("LastWordInLine")
-          : lead.IsPartOfWord
-            ? word.classList.add("PartOfWord")
-            : null;
-
-        if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-          LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-            HTMLElement: word,
-            StartTime: ConvertTime(lead.StartTime),
-            EndTime: ConvertTime(lead.EndTime),
-            TotalTime: totalDuration,
-          });
-        } else {
-          console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-        }
-      }
-
-      const prev = aL[iL - 1];
-
-      if (lead.IsPartOfWord || (prev?.IsPartOfWord && currentWordGroup)) {
-        if (!currentWordGroup) {
-          const group = document.createElement("span");
-          group.classList.add("word-group");
-          lineElem.appendChild(group);
-          currentWordGroup = group;
-        }
-
-        currentWordGroup.appendChild(word);
-
-        if (!lead.IsPartOfWord && prev?.IsPartOfWord) {
-          currentWordGroup = null;
-        }
-      } else {
-        currentWordGroup = null;
-        lineElem.appendChild(word);
-      }
+    const word = BuildSyllableWord({
+      wordData: lead,
+      isLast: iL === aL.length - 1,
+      isBackground: false,
+      useRomanized,
+      lines,
     });
 
-    if (line.Background) {
-      line.Background.forEach((bg) => {
-        const lineE = document.createElement("div");
-        lineE.classList.add("line", "bg-line");
+    currentWordGroup = AppendWordToLine(
+      lineElem,
+      word,
+      lead.IsPartOfWord ?? false,
+      aL[iL - 1]?.IsPartOfWord ?? false,
+      currentWordGroup
+    );
+  });
 
-        LyricsObject.Types.Syllable.Lines.push({
-          HTMLElement: lineE,
-          StartTime: ConvertTime(bg.StartTime),
-          EndTime: ConvertTime(bg.EndTime),
-          TotalTime: ConvertTime(bg.EndTime) - ConvertTime(bg.StartTime),
-          BGLine: true,
-        });
-        SetWordArrayInCurentLine();
+  if (line.Background) {
+    line.Background.forEach((bg) => {
+      const lineE = document.createElement("div");
+      lineE.classList.add("line", "bg-line");
 
-        if (line.OppositeAligned) {
-          lineE.classList.add("OppositeAligned");
-        }
-        lineElements.push(lineE);
-
-        let currentBGWordGroup: HTMLSpanElement | null = null;
-
-        bg.Syllables.forEach((bw, bI, bA) => {
-          let bwE = document.createElement("span");
-
-          if (isRtl(bw.Text) && !lineE.classList.contains("rtl")) {
-            lineE.classList.add("rtl");
-          }
-
-          const totalDuration = ConvertTime(bw.EndTime) - ConvertTime(bw.StartTime);
-
-          const letterLength = (
-            UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text
-          ).split("").length;
-
-          const IfLetterCapable = IsLetterCapable(letterLength, totalDuration) && !isRtl(UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text);
-
-          if (IfLetterCapable) {
-            bwE = document.createElement("div");
-            const letters = (
-              UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text
-            ).split(""); // Split word into individual letters
-
-            Emphasize(letters, bwE, bw, true);
-
-            bI === bA.length - 1
-              ? bwE.classList.add("LastWordInLine")
-              : bw.IsPartOfWord
-                ? bwE.classList.add("PartOfWord")
-                : null;
-
-            if (!$simpleLyricsMode.get()) {
-              bwE.style.setProperty("--text-shadow-opacity", `0%`);
-              bwE.style.setProperty("--text-shadow-blur-radius", `4px`);
-              bwE.style.scale = IdleEmphasisLyricsScale.toString();
-              bwE.style.transform = `translateY(calc(var(--font-size) * 0.02))`;
-            }
-          } else {
-            bwE.textContent =
-              UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text;
-
-            if (!$simpleLyricsMode.get()) {
-              bwE.style.setProperty("--gradient-position", `0%`);
-              bwE.style.setProperty("--text-shadow-opacity", `0%`);
-              bwE.style.setProperty("--text-shadow-blur-radius", `4px`);
-              bwE.style.scale = IdleLyricsScale.toString();
-              bwE.style.transform = `translateY(calc(var(--font-size) * 0.01))`;
-            }
-
-            // Check if Syllables.Lead exists
-            if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-              LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-                HTMLElement: bwE,
-                StartTime: ConvertTime(bw.StartTime),
-                EndTime: ConvertTime(bw.EndTime),
-                TotalTime: ConvertTime(bw.EndTime) - ConvertTime(bw.StartTime),
-                BGWord: true,
-              });
-            } else {
-              console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-            }
-
-            bwE.classList.add("bg-word");
-            bwE.classList.add("word");
-
-            bI === bA.length - 1
-              ? bwE.classList.add("LastWordInLine")
-              : bw.IsPartOfWord
-                ? bwE.classList.add("PartOfWord")
-                : null;
-          }
-
-          const prevBG = bA[bI - 1];
-
-          if (bw.IsPartOfWord || (prevBG?.IsPartOfWord && currentBGWordGroup)) {
-            if (!currentBGWordGroup) {
-              const group = document.createElement("span");
-              group.classList.add("word-group");
-              lineE.appendChild(group);
-              currentBGWordGroup = group;
-            }
-
-            currentBGWordGroup.appendChild(bwE);
-
-            if (!bw.IsPartOfWord && prevBG?.IsPartOfWord) {
-              currentBGWordGroup = null;
-            }
-          } else {
-            currentBGWordGroup = null;
-            lineE.appendChild(bwE);
-          }
-        });
-      });
-    }
-    if (arr[index + 1] && arr[index + 1].Lead.StartTime - line.Lead.EndTime >= getLyricsBetweenShow()) {
-      const musicalLine = document.createElement("div");
-      musicalLine.classList.add("line");
-      musicalLine.classList.add("musical-line");
-
-      LyricsObject.Types.Syllable.Lines.push({
-        HTMLElement: musicalLine,
-        StartTime: ConvertTime(line.Lead.EndTime),
-        EndTime: ConvertTime(arr[index + 1].Lead.StartTime),
-        TotalTime:
-          ConvertTime(arr[index + 1].Lead.StartTime) -
-          ConvertTime(line.Lead.EndTime),
-        DotLine: true,
+      lines.push({
+        HTMLElement: lineE,
+        StartTime: ConvertTime(bg.StartTime),
+        EndTime: ConvertTime(bg.EndTime),
+        TotalTime: ConvertTime(bg.EndTime) - ConvertTime(bg.StartTime),
+        BGLine: true,
       });
 
       SetWordArrayInCurentLine();
 
-      if (arr[index + 1].OppositeAligned) {
-        musicalLine.classList.add("OppositeAligned");
+      if (line.OppositeAligned) {
+        lineE.classList.add("OppositeAligned");
       }
 
-      const dotGroup = document.createElement("div");
-      dotGroup.classList.add("dotGroup");
+      lineElements.push(lineE);
 
-      const musicalDots1 = document.createElement("span");
-      const musicalDots2 = document.createElement("span");
-      const musicalDots3 = document.createElement("span");
+      let currentBGWordGroup: HTMLSpanElement | null = null;
 
-      const gapStartTime = ConvertTime(line.Lead.EndTime);
-      const totalTime = ConvertTime(arr[index + 1].Lead.StartTime) - gapStartTime;
-      const baseDotTime = totalTime / 3;
-      const dotPadding = getInterludeTimePadding() / 3;
-      const dot1EndTime = Math.max(gapStartTime, gapStartTime + baseDotTime + dotPadding);
-      const dot2EndTime = Math.max(dot1EndTime, gapStartTime + baseDotTime * 2 + dotPadding * 2);
-      const dot3EndTime = Math.max(dot2EndTime, gapStartTime + totalTime + getInterludeTimePadding());
+      bg.Syllables.forEach((bw, bI, bA) => {
+        if (isRtl(bw.Text) && !lineE.classList.contains("rtl")) {
+          lineE.classList.add("rtl");
+        }
 
-      musicalDots1.classList.add("word");
-      musicalDots1.classList.add("dot");
-      musicalDots1.textContent = "•";
-
-      // Check if Syllables.Lead exists
-      if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-        LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-          HTMLElement: musicalDots1,
-          StartTime: gapStartTime,
-          EndTime: dot1EndTime,
-          TotalTime: dot1EndTime - gapStartTime,
-          Dot: true,
+        const bwE = BuildSyllableWord({
+          wordData: bw,
+          isLast: bI === bA.length - 1,
+          isBackground: true,
+          useRomanized,
+          lines,
         });
-      } else {
-        console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-      }
 
-      musicalDots2.classList.add("word");
-      musicalDots2.classList.add("dot");
-      musicalDots2.textContent = "•";
-
-      // Check if Syllables.Lead exists
-      if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-        LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-          HTMLElement: musicalDots2,
-          StartTime: dot1EndTime,
-          EndTime: dot2EndTime,
-          TotalTime: dot2EndTime - dot1EndTime,
-          Dot: true,
-        });
-      } else {
-        console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-      }
-
-      musicalDots3.classList.add("word");
-      musicalDots3.classList.add("dot");
-      musicalDots3.textContent = "•";
-
-      // Check if Syllables.Lead exists
-      if (LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject]?.Syllables?.Lead) {
-        LyricsObject.Types.Syllable.Lines[CurrentLineLyricsObject].Syllables?.Lead.push({
-          HTMLElement: musicalDots3,
-          StartTime: dot2EndTime,
-          EndTime: dot3EndTime,
-          TotalTime: dot3EndTime - dot2EndTime,
-          Dot: true,
-        });
-      } else {
-        console.warn("Syllables.Lead is undefined for CurrentLineLyricsObject");
-      }
-
-      dotGroup.appendChild(musicalDots1);
-      dotGroup.appendChild(musicalDots2);
-      dotGroup.appendChild(musicalDots3);
-
-      musicalLine.appendChild(dotGroup);
-      lineElements.push(musicalLine);
-    }
-  });
-
-  ApplyLyricsCredits(data, LyricsContainer);
-  ApplyLyricsProvider(data, LyricsContainer);
-  ApplyIsByCommunity(data, LyricsContainer);
-
-  if (LyricsContainerParent) {
-    LyricsContainerInstance.Append(LyricsContainerParent);
+        currentBGWordGroup = AppendWordToLine(
+          lineE,
+          bwE,
+          bw.IsPartOfWord ?? false,
+          bA[bI - 1]?.IsPartOfWord ?? false,
+          currentBGWordGroup
+        );
+      });
+    });
   }
+}
 
-  if (ScrollSimplebar) RecalculateScrollSimplebar();
-  else MountScrollSimplebar();
+const SyllableMode: SyncedApplyMode<SyllableLineData> = {
+  typeName: "Syllable",
+  linesTarget: LyricsObject.Types.Syllable,
+  onRegularLinePushed: SetWordArrayInCurentLine,
+  onMusicalLinePushed: SetWordArrayInCurentLine,
+  extendLineEndTime: () => $minimalLyricsMode.get(),
+  getLineStartTime: (line) => line.Lead.StartTime,
+  getLineEndTime: (line) => line.Lead.EndTime,
+  buildLineContent: BuildSyllableLineContent,
+  hasRtlLines: (content) =>
+    content.some(
+      (line) =>
+        line.Lead.Syllables.some((syllable) => isRtl(syllable.Text)) ||
+        line.Background?.some((bg) => bg.Syllables.some((syllable) => isRtl(syllable.Text))) ===
+          true
+    ),
+};
 
-  const scrollEl = ScrollSimplebar?.getScrollElement() as HTMLElement | undefined;
-  if (scrollEl) initLyricsVirtualizer(scrollEl, virtualContainer, lineElements);
-
-  const LyricsStylingContainer = PageContainer?.querySelector<HTMLElement>(
-    ".LyricsContainer .LyricsContent .simplebar-content"
-  );
-
-  // Check if LyricsStylingContainer exists
-  if (LyricsStylingContainer) {
-    removeAllStyles(LyricsStylingContainer);
-
-    if (data.classes) {
-      LyricsStylingContainer.className = data.classes;
-    }
-
-    if (data.styles) {
-      applyStyles(LyricsStylingContainer, data.styles);
-    }
-  } else {
-    console.warn("LyricsStylingContainer not found");
-  }
-
-  EmitApply(data.Type, data.Content);
-
-  setRomanizedStatus(UseRomanized);
+export function ApplySyllableLyrics(data: SyllableLyricsData, UseRomanized: boolean = false): void {
+  ApplySyncedLyrics(data, UseRomanized, SyllableMode);
 }


### PR DESCRIPTION
## Summary

`ApplySyllableLyrics` (`Syllable.ts`, 566 lines) and `ApplyLineLyrics` (`Line.ts`, 334 lines) were ~80% structurally identical: container setup, RTL/duet detection, musical interlude dots, line-end-time computation, credits/provider application, SimpleBar/virtualizer wiring, and styling all existed twice with only minor differences (lines array, `SetWordArray*` hook, end-time store flag, word-building).

This PR extracts the shared pipeline into a new `Synced/Base.ts` and parameterizes the differences through a small `SyncedApplyMode` config:

- **`Synced/Base.ts`** (new, ~290 lines) — `ApplySyncedLyrics`, `CreateMusicalLine` (unified leading + gap interlude builder), `PushSyncedWord`, shared types
- **`Syllable.ts`** — 566 → ~260 lines; keeps all word-level logic: letter emphasis (`Emphasize`), word grouping, background lines
- **`Line.ts`** — 334 → ~46 lines; just its types, the `textContent` builder, and mode config

Net **−591 lines** (`+508/−807` across 3 files).

## Behavior preserved (verified line-by-line)

- `$minimalLyricsMode` (Syllable) vs `$simpleLyricsMode` (Line) end-time extension stays separate
- `SetWordArrayInCurentLine` / `SetWordArrayInCurentLine_LINE_SYNCED` called at the exact same points — critical because `Emphasize` reads the global `CurrentLineLyricsObject`; LINE_SYNCED regular lines still get no word array
- Musical-dot timing math identical (leading and gap cases unify to the same formula with `lineStartTime = 0`)
- BG-word class asymmetry preserved (`bg-word` only on non-letter background words), `BGWord: true` pushes intact
- Target lines array resolved *after* `ClearLyricsContentArrays` (which swaps in fresh arrays)
- The two previously unguarded dot pushes in `Line.ts` are now guarded — behaviorally identical since `Syllables.Lead` is always initialized before them
- Public APIs (`ApplySyllableLyrics`, `ApplyLineLyrics`) unchanged; no other files touched

## Verification

- `bun run build` — 198 modules, success (production + dev watcher)
- `bun run lint` — no new warnings
- `oxfmt --check` — clean
- `tsc --noEmit` — identical set of pre-existing errors before/after, none in the touched files
