### PR TITLE
fix: repair listener, scope, and event-dispatch lifecycle bugs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -62,6 +62,7 @@ import Logger from "./utils/Logger.ts";
 import Whentil from "./modules/Whentil.ts";
 import App from "./utils/app.ts";
 import { initSession } from "./utils/SessionManager/index.ts";
+import { ensurePersistence } from "./utils/db.ts";
 
 async function main() {
   const appLogger = new Logger("App");
@@ -108,6 +109,7 @@ async function main() {
   window._spicy_lyrics_metadata = {};
 
   void initSession();
+  void ensurePersistence();
 
   LoadFonts();
   ApplyFontPixel();

--- a/src/components/Global/Global.ts
+++ b/src/components/Global/Global.ts
@@ -17,7 +17,7 @@ const Global = {
 
       if (i === keys.length - 1) {
         // If we're at the last key, assign the value
-        current[part] = current[part] ?? value; // Assign only if it doesn't already exist
+        current[part] = value;
       } else {
         // If the current part doesn't exist, initialize it as an object
         if (!current[part]) {

--- a/src/utils/API/Query.ts
+++ b/src/utils/API/Query.ts
@@ -25,6 +25,15 @@ export interface QueryResultGetter {
 
 const queryLogger = new Logger("API Query");
 
+const SENSITIVE_HEADER_PATTERN = /auth|token|cookie|secret|key/i;
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    redacted[name] = SENSITIVE_HEADER_PATTERN.test(name) ? "[redacted]" : value;
+  }
+  return redacted;
+}
 
 export async function Query(
   queries: Query[],
@@ -37,7 +46,7 @@ export async function Query(
     queries,
     host,
     clientVersion: clientVersion?.Text,
-    headers,
+    headers: redactHeaders(headers),
   });
 
   try {

--- a/src/utils/EventManager.ts
+++ b/src/utils/EventManager.ts
@@ -1,3 +1,5 @@
+import Logger from "./Logger.ts";
+
 // Define types for the event system
 type EventCallback = (...args: any[]) => void;
 type EventId = number;
@@ -6,6 +8,8 @@ type EventListeners = Map<EventId, EventCallback>;
 const eventRegistry = new Map<string, EventListeners>();
 
 let nextId = 1;
+
+const eventLogger = new Logger("Event Manager");
 
 const listen = (eventName: string, callback: EventCallback): EventId => {
   if (!eventRegistry.has(eventName)) {
@@ -37,7 +41,11 @@ const evoke = (eventName: string, ...args: any[]): void => {
   const listeners = eventRegistry.get(eventName);
   if (listeners) {
     for (const callback of listeners.values()) {
-      callback(...args);
+      try {
+        callback(...args);
+      } catch (error) {
+        eventLogger.error(`A listener for "${eventName}" threw`, error);
+      }
     }
   }
 };

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -42,11 +42,6 @@ const wasDrasticPositionChange = (lastPosition: number, newPosition: number) => 
   return positionChange > 1000;
 };
 
-// Add focus event listener to reset state when window is focused
-window.addEventListener("focus", ResetLastLine);
-// Add resize event listener to reset state when window is resized
-window.addEventListener("resize", ResetLastLine);
-
 // Create ResizeObserver to monitor LyricsContent container dimensions
 const lyricsContentObserver = new ResizeObserver(() => {
   ResetLastLine();
@@ -87,6 +82,9 @@ function handleUserScroll(ScrollSimplebar: any | null) {
 // Initialization function for scroll events and observers
 export function InitializeScrollEvents(ScrollSimplebar: any) {
   if (!$lyricsContainerExists.get()) return;
+
+  window.addEventListener("focus", ResetLastLine);
+  window.addEventListener("resize", ResetLastLine);
   // --- NEW: Store instance and define handlers ---
   currentSimpleBarInstance = ScrollSimplebar;
   wheelHandler = () => handleUserScroll(currentSimpleBarInstance);


### PR DESCRIPTION
### `fix(scrolling)` — scroll re-centering dies after the first page close

`window.addEventListener("focus"/"resize", ResetLastLine)` was registered once at module scope, but `CleanupScrollEvents()` removes both — and it runs on every `DestroyPage()`. `InitializeScrollEvents()` never re-added them.

Repro: open the lyrics page, close it, reopen it. From then on, resizing the Spotify window or alt-tabbing back no longer re-centers the active line, and it stays broken until the client restarts.

Registration now lives in `InitializeScrollEvents()` so it pairs with the existing cleanup. `ResetLastLine` is a hoisted `export function`, and `addEventListener` de-duplicates identical listener references, so repeated init can't stack them.

### `fix(global)` — `SetScope` could never overwrite a leaf

The leaf assignment was `current[part] = current[part] ?? value`. `??` only falls through on `null`/`undefined`, so any key already holding a real value was frozen. `fullscreen.open` is seeded `false` at startup and then set `true` on open — `false ?? true` is `false`, so `window._spicy_lyrics.fullscreen.open` never reported an open fullscreen.

All five call sites are in `app.tsx` and all expect overwrite semantics.

### `fix(events)` — one throwing listener stopped every listener after it

`evoke` iterated `listeners.values()` with no error handling. A single handler throwing on `playback:songchange` silently skipped every listener registered after it, leaving a half-updated UI with nothing in the console — and it self-heals on the next track, which makes it very hard to reproduce from a bug report.

Each callback is now isolated; failures are logged rather than swallowed.

### `fix(api)` — the request log included the auth header

`queryLogger.info(...)` passed the raw `headers` object, which carries the Spotify token as `Authorization` or `SpicyLyrics-WebAuth`. It's gated behind developer mode, but that's a one-click toggle, and "paste your console output" is the normal bug-report flow — so a live session token can end up in a public issue. Header values are now redacted by name.

### `fix(db)` — `ensurePersistence()` was never called

It was written but had no call site (`grep -rn ensurePersistence src` returned only its own definition). The IndexedDB store holds user-uploaded TTML, which is the only lyrics data a user can't re-download, and without the persistence request it sits in the browser's default evictable bucket.

---

**Testing:** `oxlint` passes clean on all five files against the repo's own `.oxlintrc.json`. I wasn't able to run a full `bun install` / build locally, so a CI run or a quick smoke test would be worth having before merge.
