### PR TITLE
Update 6.3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ src/components/cli-sync
 CHANGELOG.md
 
 VOLUME_SLIDER_PLAN.md
+
+api-backend/
+
+docs/

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "cubic-spline": "^3.0.3",
         "cyrillic-romanization": "^1.2.1",
         "d3-ease": "^3.0.1",
+        "fast-xml-parser": "^5.11.0",
         "franc-all": "^7.2.0",
         "idb": "^8.0.3",
         "kuroshiro": "^1.2.0",
@@ -212,6 +213,8 @@
 
     "@nanostores/react": ["@nanostores/react@1.1.0", "", { "peerDependencies": { "nanostores": "^1.2.0", "react": ">=18.0.0" } }, "sha512-MbH35fjhcf7LAubYX5vhOChYUfTLzNLqH/mBGLVsHkcvjy0F8crO1WQwdmQ2xKbAmtpalDa2zBt3Hlg5kqr8iw=="],
 
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.41.0", "", { "os": "android", "cpu": "arm" }, "sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw=="],
 
     "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.41.0", "", { "os": "android", "cpu": "arm64" }, "sha512-s0b1dxNgb2KomspFV2LfogC2XtSJB42POXF4bMCLJyvQmAGos4ZtjGPfQreToQEaY0FQFjz3030ggI36rF1q5g=="],
@@ -338,6 +341,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -414,6 +419,10 @@
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.11.0", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -466,6 +475,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
@@ -509,6 +520,8 @@
     "oxfmt": ["oxfmt@0.41.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.41.0", "@oxfmt/binding-android-arm64": "0.41.0", "@oxfmt/binding-darwin-arm64": "0.41.0", "@oxfmt/binding-darwin-x64": "0.41.0", "@oxfmt/binding-freebsd-x64": "0.41.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.41.0", "@oxfmt/binding-linux-arm-musleabihf": "0.41.0", "@oxfmt/binding-linux-arm64-gnu": "0.41.0", "@oxfmt/binding-linux-arm64-musl": "0.41.0", "@oxfmt/binding-linux-ppc64-gnu": "0.41.0", "@oxfmt/binding-linux-riscv64-gnu": "0.41.0", "@oxfmt/binding-linux-riscv64-musl": "0.41.0", "@oxfmt/binding-linux-s390x-gnu": "0.41.0", "@oxfmt/binding-linux-x64-gnu": "0.41.0", "@oxfmt/binding-linux-x64-musl": "0.41.0", "@oxfmt/binding-openharmony-arm64": "0.41.0", "@oxfmt/binding-win32-arm64-msvc": "0.41.0", "@oxfmt/binding-win32-ia32-msvc": "0.41.0", "@oxfmt/binding-win32-x64-msvc": "0.41.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-sKLdJZdQ3bw6x9qKiT7+eID4MNEXlDHf5ZacfIircrq6Qwjk0L6t2/JQlZZrVHTXJawK3KaMuBoJnEJPcqCEdg=="],
 
     "oxlint": ["oxlint@1.67.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.67.0", "@oxlint/binding-android-arm64": "1.67.0", "@oxlint/binding-darwin-arm64": "1.67.0", "@oxlint/binding-darwin-x64": "1.67.0", "@oxlint/binding-freebsd-x64": "1.67.0", "@oxlint/binding-linux-arm-gnueabihf": "1.67.0", "@oxlint/binding-linux-arm-musleabihf": "1.67.0", "@oxlint/binding-linux-arm64-gnu": "1.67.0", "@oxlint/binding-linux-arm64-musl": "1.67.0", "@oxlint/binding-linux-ppc64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-musl": "1.67.0", "@oxlint/binding-linux-s390x-gnu": "1.67.0", "@oxlint/binding-linux-x64-gnu": "1.67.0", "@oxlint/binding-linux-x64-musl": "1.67.0", "@oxlint/binding-openharmony-arm64": "1.67.0", "@oxlint/binding-win32-arm64-msvc": "1.67.0", "@oxlint/binding-win32-ia32-msvc": "1.67.0", "@oxlint/binding-win32-x64-msvc": "1.67.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
@@ -670,6 +683,8 @@
 
     "string-hash": ["string-hash@1.1.3", "", {}, "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A=="],
 
+    "strnum": ["strnum@2.4.2", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -709,6 +724,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "@spicemod/creator/nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cubic-spline": "^3.0.3",
     "cyrillic-romanization": "^1.2.1",
     "d3-ease": "^3.0.1",
+    "fast-xml-parser": "^5.11.0",
     "franc-all": "^7.2.0",
     "idb": "^8.0.3",
     "kuroshiro": "^1.2.0",

--- a/project/config.ts
+++ b/project/config.ts
@@ -1,2 +1,2 @@
 export const ProjectName = "spicy-lyrics";
-export const ProjectVersion = "6.3.1";
+export const ProjectVersion = "6.3.10";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -979,19 +979,28 @@ async function main() {
           clearTimeout(lastTimeout);
           lastTimeout = undefined;
         }
-        lastTimeout = setTimeout(async () => {
+        lastTimeout = setTimeout(() => {
+          // Safety net: whatever is on screen belongs to `$currentLyricsData`.
+          // If that payload (or "no lyrics" sentinel) is for a different track
+          // than the one playing, the pipeline was raced — re-fetch so the
+          // playing track gets its own lyrics instead of the previous track's.
           const currentSongLyrics = $currentLyricsData.get();
-          if (
-            currentSongLyrics &&
-            currentSongLyrics !== `NO_LYRICS:${SpotifyPlayer.GetUri()}`
-          ) {
-            const parsedLyrics = JSON.parse(currentSongLyrics);
-            if (parsedLyrics?.uri !== SpotifyPlayer.GetUri()) {
-              const refetchUri = SpotifyPlayer.GetUri();
-              if (refetchUri) {
-                fetchLyrics(refetchUri).then(ApplyLyrics);
-              }
+          const refetchUri = SpotifyPlayer.GetUri();
+          if (!currentSongLyrics || !refetchUri) return;
+
+          let appliedUri: string | null = null;
+          if (currentSongLyrics.startsWith("NO_LYRICS:")) {
+            appliedUri = currentSongLyrics.slice("NO_LYRICS:".length);
+          } else {
+            try {
+              appliedUri = JSON.parse(currentSongLyrics)?.uri ?? null;
+            } catch {
+              appliedUri = null;
             }
+          }
+
+          if (appliedUri !== refetchUri) {
+            fetchLyrics(refetchUri).then(ApplyLyrics);
           }
         }, 1000);
       });
@@ -1064,13 +1073,30 @@ async function main() {
 
   runThemeMatcher();
 
-  Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.ESCAPE, async () => {
-    if (IsPIP) return;
-    if (Fullscreen.CinemaViewOpen) {
-      await Fullscreen.Close();
-      Session.GoBack();
-    }
-  });
+  setTimeout(() => {
+    Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.ESCAPE, async () => {
+      if (IsPIP) return;
+      if (Fullscreen.CinemaViewOpen) {
+        await Fullscreen.Close();
+        Session.GoBack();
+      }
+    });
+
+    Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.F11, async () => {
+      if (IsPIP) return;
+      if (Fullscreen.IsOpen) {
+        if (!Fullscreen.CinemaViewOpen) {
+          Fullscreen.CinemaViewOpen = true;
+          await ExitFullscreenElement();
+          PageView.AppendViewControls(true);
+        } else {
+          Fullscreen.CinemaViewOpen = false;
+          await EnterSpicyLyricsFullscreen();
+          PageView.AppendViewControls(true);
+        }
+      }
+    });
+  }, 3000);
 
   document.addEventListener("fullscreenchange", async () => {
     if (!document.fullscreenElement && Fullscreen.IsOpen && !Fullscreen.CinemaViewOpen) {
@@ -1080,20 +1106,7 @@ async function main() {
     }
   });
 
-  Spicetify.Keyboard.registerImportantShortcut(Spicetify.Keyboard.KEYS.F11, async () => {
-    if (IsPIP) return;
-    if (Fullscreen.IsOpen) {
-      if (!Fullscreen.CinemaViewOpen) {
-        Fullscreen.CinemaViewOpen = true;
-        await ExitFullscreenElement();
-        PageView.AppendViewControls(true);
-      } else {
-        Fullscreen.CinemaViewOpen = false;
-        await EnterSpicyLyricsFullscreen();
-        PageView.AppendViewControls(true);
-      }
-    }
-  });
+  
 
   new Spicetify.Menu.Item(
 		"Spicy Lyrics Settings",

--- a/src/components/Global/Platform.ts
+++ b/src/components/Global/Platform.ts
@@ -5,6 +5,17 @@ type TokenProviderResponse = {
   tokenType: "Bearer";
 };
 
+/** Shape returned by `Spicetify.Platform.AuthorizationAPI.getState()`. */
+type AuthorizationState = {
+  isAuthorized?: boolean;
+  token?: {
+    accessToken?: string;
+    accessTokenExpirationTimestampMs?: number;
+    tokenType?: string;
+    isAnonymous?: boolean;
+  } | null;
+};
+
 // Store all our Spotify Services
 const Spotify: typeof Spicetify = (globalThis as any).Spicetify;
 let SpotifyPlatform: typeof Spicetify.Platform;
@@ -31,46 +42,105 @@ const OnSpotifyReady = new Promise<void>((resolve) => {
 let tokenProviderResponse: TokenProviderResponse | undefined;
 let accessTokenPromise: Promise<string> | undefined;
 
-const GetSpotifyAccessToken = (): Promise<string> => {
-  if (tokenProviderResponse) {
-    const timeUntilRefresh = tokenProviderResponse.expiresAtTime - Date.now();
-    if (timeUntilRefresh <= 2) {
-      tokenProviderResponse = undefined;
-      accessTokenPromise = new Promise((resolve) => setTimeout(resolve, timeUntilRefresh)).then(() => {
-        accessTokenPromise = undefined;
-        return GetSpotifyAccessToken();
-      });
-      return accessTokenPromise;
+/** A cached token is reusable until it's within this margin of expiring. */
+const TOKEN_EXPIRY_MARGIN_MS = 2;
+
+function isUsable(response: TokenProviderResponse | undefined): response is TokenProviderResponse {
+  if (!response?.accessToken) return false;
+  // Some sources don't report an expiry — treat those as usable and let a 401
+  // from the API drive the next refresh.
+  if (typeof response.expiresAtTime !== "number" || !Number.isFinite(response.expiresAtTime)) {
+    return true;
+  }
+  return response.expiresAtTime - Date.now() > TOKEN_EXPIRY_MARGIN_MS;
+}
+
+/**
+ * Preferred source on current Spotify clients: the platform's own authorization
+ * store. `getState()` is a plain synchronous getter over the cached state.
+ */
+function tokenFromAuthorizationAPI(): TokenProviderResponse | undefined {
+  try {
+    const api = (SpotifyPlatform as any)?.AuthorizationAPI;
+    if (typeof api?.getState !== "function") return undefined;
+
+    const state: AuthorizationState = api.getState();
+    const token = state?.token;
+    if (!token?.accessToken) return undefined;
+    if (state.isAuthorized === false) return undefined;
+
+    return {
+      accessToken: token.accessToken,
+      expiresAtTime: token.accessTokenExpirationTimestampMs as number,
+      tokenType: "Bearer",
+    };
+  } catch (error) {
+    console.warn("AuthorizationAPI.getState() failed, falling back", error);
+    return undefined;
+  }
+}
+
+/**
+ * Legacy path, kept as the fallback: the Cosmos oauth resolver, and — on clients
+ * where that resolver is gone — `Platform.Session`.
+ */
+async function tokenFromLegacySources(): Promise<TokenProviderResponse | undefined> {
+  try {
+    const result: TokenProviderResponse = await SpotifyInternalFetch.get("sp://oauth/v2/token");
+    if (result?.accessToken) {
+      return {
+        accessToken: result.accessToken,
+        expiresAtTime: result.expiresAtTime,
+        tokenType: "Bearer",
+      };
     }
+  } catch (error) {
+    console.warn("sp://oauth/v2/token failed, falling back to Platform.Session", error);
   }
 
-  if (accessTokenPromise) {
-    return accessTokenPromise;
+  const session = (SpotifyPlatform as any)?.Session;
+  if (!session?.accessToken) {
+    console.warn("Failed to find SpotifyPlatform.Session for fetching token");
+    return undefined;
   }
 
-  accessTokenPromise = SpotifyInternalFetch.get("sp://oauth/v2/token")
-    .then((result: TokenProviderResponse) => {
-      tokenProviderResponse = result;
-      accessTokenPromise = Promise.resolve(result.accessToken);
-      return GetSpotifyAccessToken();
-    })
-    .catch((error: Error) => {
-      if (error.message.includes("Resolver not found")) {
-        if (!SpotifyPlatform.Session) {
-          console.warn("Failed to find SpotifyPlatform.Session for fetching token");
-        } else {
-          tokenProviderResponse = {
-            accessToken: SpotifyPlatform.Session.accessToken,
-            expiresAtTime: SpotifyPlatform.Session.accessTokenExpirationTimestampMs,
-            tokenType: "Bearer",
-          };
-          accessTokenPromise = Promise.resolve(tokenProviderResponse.accessToken);
-        }
-      }
-      return GetSpotifyAccessToken();
-    });
+  return {
+    accessToken: session.accessToken,
+    expiresAtTime: session.accessTokenExpirationTimestampMs,
+    tokenType: "Bearer",
+  };
+}
 
-  return accessTokenPromise;
+async function resolveAccessToken(): Promise<string> {
+  await OnSpotifyReady;
+
+  const response = tokenFromAuthorizationAPI() ?? (await tokenFromLegacySources());
+
+  if (!response?.accessToken) {
+    throw new Error("Unable to obtain a Spotify access token");
+  }
+
+  tokenProviderResponse = response;
+  return response.accessToken;
+}
+
+const GetSpotifyAccessToken = (): Promise<string> => {
+  if (isUsable(tokenProviderResponse)) {
+    return Promise.resolve(tokenProviderResponse.accessToken);
+  }
+
+  // Expired (or unusable) — drop it so a failed refresh can't hand it back out.
+  tokenProviderResponse = undefined;
+
+  // De-duplicate concurrent callers, but never cache the promise past its
+  // settlement: a rejection must not poison every later call.
+  if (accessTokenPromise) return accessTokenPromise;
+
+  const pending = resolveAccessToken().finally(() => {
+    if (accessTokenPromise === pending) accessTokenPromise = undefined;
+  });
+  accessTokenPromise = pending;
+  return pending;
 };
 
 const Platform = {

--- a/src/components/ReactComponents/LyricsManager/components/Icons.tsx
+++ b/src/components/ReactComponents/LyricsManager/components/Icons.tsx
@@ -50,3 +50,48 @@ export function ResetIcon({ size = 16, className }: IconProps) {
     </svg>
   );
 }
+
+export function DatabaseIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+      <ellipse cx="8" cy="3.75" rx="5.25" ry="2.25" stroke="currentColor" strokeWidth="1.5"/>
+      <path d="M2.75 3.75v8.5c0 1.24 2.35 2.25 5.25 2.25s5.25-1.01 5.25-2.25v-8.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      <path d="M2.75 8c0 1.24 2.35 2.25 5.25 2.25S13.25 9.24 13.25 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+export function ClockIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+      <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.5"/>
+      <path d="M8 4.5V8l2.25 1.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+export function FileIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+      <path d="M9 1.75H4.5a1.25 1.25 0 00-1.25 1.25v10a1.25 1.25 0 001.25 1.25h7A1.25 1.25 0 0012.75 13V5.5L9 1.75z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+      <path d="M8.75 2v3.25H12" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+export function CheckIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+      <path d="M3 8.5l3.25 3.25L13 5" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+export function SpinnerIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={`sl-ldb-spinner${className ? ` ${className}` : ""}`} aria-hidden="true">
+      <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.5" opacity="0.25"/>
+      <path d="M14.25 8A6.25 6.25 0 008 1.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}

--- a/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
+++ b/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
@@ -1,14 +1,14 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useStore } from "@nanostores/react";
 import { toast } from "sonner";
 import { SpotifyPlayer } from "../../../../components/Global/SpotifyPlayer";
 import fetchLyrics from "../../../../utils/Lyrics/fetchLyrics";
 import ApplyLyrics from "../../../../utils/Lyrics/Global/Applyer";
 import { ParseTTML } from "../../../../utils/Lyrics/manager/parseTTML";
 import { ProcessLyrics } from "../../../../utils/Lyrics/ProcessLyrics";
-import { $currentLyricsData } from "../../../../utils/stores";
+import { $currentLyricsData, $ttmlUploadMode } from "../../../../utils/stores";
 import { LocalLyricsManager } from "../../../../utils/Lyrics/manager";
-import { IconButton } from "./IconButton";
-import { ArrowLeftIcon, UploadIcon } from "./Icons";
+import { ArrowLeftIcon, ClockIcon, DatabaseIcon, SpinnerIcon, UploadIcon } from "./Icons";
 
 type UploadMode = "persistent" | "temporary";
 
@@ -17,140 +17,194 @@ type UploadTTMLModalProps = {
   onDone: (mode: UploadMode) => void;
 };
 
+const MODES: { id: UploadMode; label: string; hint: string; icon: React.ReactNode }[] = [
+  {
+    id: "persistent",
+    label: "Save",
+    hint: "Store in the local DB — survives restarts",
+    icon: <DatabaseIcon size={14} />,
+  },
+  {
+    id: "temporary",
+    label: "Just once",
+    hint: "Apply to the current song only, until refresh",
+    icon: <ClockIcon size={14} />,
+  },
+];
+
 export default function UploadTTMLModal({ onBack, onDone }: UploadTTMLModalProps) {
-  const [file, setFile] = useState<File | null>(null);
-  const [mode, setMode] = useState<UploadMode>("persistent");
+  // Persisted, so the screen reopens on whichever mode was used last.
+  const storedMode = useStore($ttmlUploadMode);
+  const mode: UploadMode = storedMode === "temporary" ? "temporary" : "persistent";
+  const setMode = (m: UploadMode) => $ttmlUploadMode.set(m);
+
   const [uploading, setUploading] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // The handlers below are re-created on every render, so keep the live values
+  // in refs — the paste listener is bound once.
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const uploadingRef = useRef(uploading);
+  uploadingRef.current = uploading;
 
   const songName = SpotifyPlayer.GetName() ?? "Unknown Song";
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0] ?? null;
-    setFile(f);
+  /** Read + apply a file straight away — picking the file *is* the upload. */
+  const startUpload = useCallback(
+    (file: File | null | undefined) => {
+      if (!file || uploadingRef.current) return;
+
+      // `accept` only filters the picker — drag & drop and paste bypass it.
+      if (!file.name.toLowerCase().endsWith(".ttml")) {
+        toast.error("Only .ttml files are supported.", { duration: 5000 });
+        return;
+      }
+
+      const uri = SpotifyPlayer.GetUri();
+      if (!uri) {
+        toast.error("No track is currently playing.", { duration: 5000 });
+        return;
+      }
+
+      const uploadMode = modeRef.current;
+      setUploading(true);
+
+      const reader = new FileReader();
+      reader.onerror = () => {
+        toast.error("Error reading TTML file.", { duration: 5000 });
+        setUploading(false);
+      };
+      reader.onload = async (e) => {
+        try {
+          const ttml = e.target?.result as string;
+
+          if (uploadMode === "persistent") {
+            await LocalLyricsManager.put(uri, ttml);
+            $currentLyricsData.set("");
+            setTimeout(() => {
+              fetchLyrics(uri).then(ApplyLyrics);
+            }, 25);
+            toast.success("TTML saved to Local DB!", { duration: 5000 });
+            onDone("persistent");
+          } else {
+            const result = ParseTTML(ttml);
+            if (!result) {
+              toast.error("Failed to parse TTML.", { duration: 5000 });
+              setUploading(false);
+              return;
+            }
+            const dataToSave = { ...result, uri };
+            await ProcessLyrics(dataToSave);
+            $currentLyricsData.set(JSON.stringify(dataToSave));
+            setTimeout(() => {
+              fetchLyrics(uri)
+                .then((lyrics) => {
+                  ApplyLyrics(lyrics);
+                  toast.success("Lyrics Parsed and Applied!", { duration: 5000 });
+                })
+                .catch((err) => {
+                  toast.error("Error applying lyrics", { duration: 5000 });
+                  console.error("Error applying lyrics:", err);
+                });
+            }, 25);
+            onDone("temporary");
+          }
+        } catch (err) {
+          toast.error("Upload failed.", { duration: 5000 });
+          console.error("TTML upload error:", err);
+          setUploading(false);
+        }
+      };
+      reader.readAsText(file);
+    },
+    [onDone]
+  );
+
+  // Ctrl+V a copied .ttml file to upload it without touching the picker.
+  useEffect(() => {
+    function onPaste(e: ClipboardEvent) {
+      const file = e.clipboardData?.files?.[0];
+      if (!file) return;
+      e.preventDefault();
+      startUpload(file);
+    }
+    document.addEventListener("paste", onPaste);
+    return () => document.removeEventListener("paste", onPaste);
+  }, [startUpload]);
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+    startUpload(e.dataTransfer.files?.[0]);
   }
 
-  async function handleUpload() {
-    if (!file || uploading) return;
-
-    const uri = SpotifyPlayer.GetUri();
-    if (!uri) {
-      toast.error("No track is currently playing.", { duration: 5000 });
-      return;
-    }
-
-    setUploading(true);
-
-    const reader = new FileReader();
-    reader.onerror = () => {
-      toast.error("Error reading TTML file.", { duration: 5000 });
-      setUploading(false);
-    };
-    reader.onload = async (e) => {
-      try {
-        const ttml = e.target?.result as string;
-
-        if (mode === "persistent") {
-          await LocalLyricsManager.put(uri, ttml);
-          $currentLyricsData.set("");
-          setTimeout(() => {
-            fetchLyrics(uri)
-              .then(ApplyLyrics)
-          }, 25);
-          toast.success("TTML saved to Local DB!", { duration: 5000 });
-          onDone("persistent");
-        } else {
-          toast("Found TTML, Parsing...", { duration: 3000 });
-          const result = await ParseTTML(ttml);
-          if (!result) {
-            toast.error("Failed to parse TTML.", { duration: 5000 });
-            setUploading(false);
-            return;
-          }
-          const dataToSave = {
-            ...result?.Result,
-            uri,
-          };
-          await ProcessLyrics(dataToSave);
-          $currentLyricsData.set(JSON.stringify(dataToSave));
-          setTimeout(() => {
-            fetchLyrics(uri)
-              .then((lyrics) => {
-                ApplyLyrics(lyrics);
-                toast.success("Lyrics Parsed and Applied!", { duration: 5000 });
-              })
-              .catch((err) => {
-                toast.error("Error applying lyrics", { duration: 5000 });
-                console.error("Error applying lyrics:", err);
-              });
-          }, 25);
-          onDone("temporary");
-        }
-      } catch (err) {
-        toast.error("Upload failed.", { duration: 5000 });
-        console.error("TTML upload error:", err);
-        setUploading(false);
-      }
-    };
-    reader.readAsText(file);
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    startUpload(e.target.files?.[0]);
+    // Allow re-picking the same file after a failed attempt.
+    e.target.value = "";
   }
 
   return (
     <div className="sl-ldb-upload-root">
-      <div className="sl-ldb-upload-header">
-        <h2 className="sl-ldb-upload-title">Upload TTML</h2>
-        <p className="sl-ldb-upload-subtitle">For: {songName}</p>
-      </div>
-
-      <div className="sl-ldb-upload-file-section">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".ttml"
-          id="sl-ldb-file-input"
-          className="sl-ldb-file-input"
-          onChange={handleFileChange}
-        />
-        <label htmlFor="sl-ldb-file-input" className="sl-ldb-file-label">
-          {file ? file.name : "Choose .ttml file…"}
-        </label>
-      </div>
-
-      <div className="sl-ldb-upload-mode-section">
+      <div className="sl-ldb-upload-bar">
         <button
           type="button"
-          className={`sl-ldb-upload-mode-card${mode === "persistent" ? " sl-ldb-upload-mode-card--active" : ""}`}
-          onClick={() => setMode("persistent")}
-        >
-          <span className="sl-ldb-upload-mode-title">Persistent Upload</span>
-          <span className="sl-ldb-upload-mode-desc">Stored in local DB, survives restarts</span>
-        </button>
-        <button
-          type="button"
-          className={`sl-ldb-upload-mode-card${mode === "temporary" ? " sl-ldb-upload-mode-card--active" : ""}`}
-          onClick={() => setMode("temporary")}
-        >
-          <span className="sl-ldb-upload-mode-title">Temporary Upload</span>
-          <span className="sl-ldb-upload-mode-desc">Applied only to current song until refresh</span>
-        </button>
-      </div>
-
-      <div className="sl-ldb-upload-actions">
-        <IconButton
-          icon={<ArrowLeftIcon size={14} />}
-          label="Back"
-          variant="default"
+          className="sl-ldb-upload-back"
           onClick={onBack}
           disabled={uploading}
-        />
-        <IconButton
-          icon={<UploadIcon size={14} />}
-          label={uploading ? "Uploading…" : "Upload"}
-          variant="primary"
-          onClick={handleUpload}
-          disabled={!file || uploading}
-        />
+          title="Back to Local Lyrics DB"
+          aria-label="Back"
+        >
+          <ArrowLeftIcon size={14} />
+        </button>
+
+        <div className="sl-ldb-upload-modes" role="radiogroup" aria-label="Upload mode">
+          {MODES.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              role="radio"
+              aria-checked={mode === m.id}
+              className={`sl-ldb-upload-mode${mode === m.id ? " sl-ldb-upload-mode--active" : ""}`}
+              onClick={() => setMode(m.id)}
+              disabled={uploading}
+              title={m.hint}
+            >
+              {m.icon}
+              <span>{m.label}</span>
+            </button>
+          ))}
+        </div>
       </div>
+
+      <input
+        type="file"
+        accept=".ttml"
+        id="sl-ldb-file-input"
+        className="sl-ldb-file-input"
+        onChange={handleFileChange}
+      />
+      <label
+        htmlFor="sl-ldb-file-input"
+        className={`sl-ldb-dropzone${dragging ? " sl-ldb-dropzone--dragging" : ""}${uploading ? " sl-ldb-dropzone--busy" : ""}`}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!uploading) setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={handleDrop}
+      >
+        <span className="sl-ldb-dropzone-icon">
+          {uploading ? <SpinnerIcon size={26} /> : <UploadIcon size={26} />}
+        </span>
+        <span className="sl-ldb-dropzone-title">
+          {uploading ? "Uploading…" : dragging ? "Drop to upload" : "Drop a .ttml file or click to browse"}
+        </span>
+        <span className="sl-ldb-dropzone-sub">
+          {mode === "persistent" ? "Saves to Local DB for" : "Applies once to"} {songName}
+        </span>
+      </label>
     </div>
   );
 }

--- a/src/components/ReactComponents/LyricsManager/index.tsx
+++ b/src/components/ReactComponents/LyricsManager/index.tsx
@@ -41,6 +41,12 @@ export default function LyricsDBPanel({ onUploadClick }: LyricsDBPanelProps) {
 
   const filtered = uris.filter(matchesQuery);
 
+  // Pin the currently playing track to the top of the list.
+  const currentIndex = currentUri ? filtered.indexOf(currentUri) : -1;
+  if (currentIndex > 0) {
+    filtered.unshift(filtered.splice(currentIndex, 1)[0]);
+  }
+
   async function handleDownload(uri: string) {
     const ttml = await getRaw(uri);
     if (!ttml) {

--- a/src/components/ReactComponents/LyricsManager/styles.css
+++ b/src/components/ReactComponents/LyricsManager/styles.css
@@ -261,149 +261,167 @@ sl-generic-modal.SpicyLyricsModal .sl-modal-overlay .sl-ldb-icon-btn {
 }
 
 /* ── Upload TTML Modal ───────────────────────────────────────── */
+/* One screen, one gesture: pick the mode (or leave the default) and drop /
+   click the file — selecting the file performs the upload. */
 sl-generic-modal.SpicyLyricsModal .sl-modal-overlay .sl-ldb-upload-root {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
-  padding: var(--space-2) 4px;
+  gap: var(--space-3);
+  padding: 2px 4px 4px;
 
-  .sl-ldb-upload-header {
-    .sl-ldb-upload-title {
-      margin: 0 0 var(--space-1);
-      font-size: 1.2rem !important;
-      font-weight: var(--w-semibold);
+  .sl-ldb-upload-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .sl-ldb-upload-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: var(--accent-tint-bg);
+    box-shadow: inset 0 0 0 1px var(--hairline);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      background var(--dur-fast) var(--ease-standard),
+      color var(--dur-fast) var(--ease-standard);
+
+    &:hover:not(:disabled) {
+      background: var(--accent-tint-bg-hover);
       color: var(--color-text-primary);
-      line-height: 1.3;
-      letter-spacing: -0.01em;
     }
 
-    .sl-ldb-upload-subtitle {
-      margin: 0;
-      font-size: var(--text-body-size) !important;
-      color: var(--color-text-secondary);
+    &:disabled {
+      opacity: 0.4;
+      cursor: default;
     }
   }
 
-  .sl-ldb-upload-file-section {
-    .sl-ldb-file-input {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      opacity: 0;
-      pointer-events: none;
-    }
+  /* Segmented mode switch — replaces the two full-width choice cards. */
+  .sl-ldb-upload-modes {
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    background: var(--accent-tint-bg);
+    box-shadow: inset 0 0 0 1px var(--hairline);
 
-    .sl-ldb-file-label {
+    .sl-ldb-upload-mode {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-2);
-      height: var(--tap-min-primary);
-      padding: 0 18px;
-      border-radius: var(--radius-sm);
-      background: var(--accent-tint-bg);
-      box-shadow: inset 0 0 0 1px var(--hairline);
-      color: var(--color-text-primary);
-      font-size: var(--text-body-size) !important;
+      gap: 6px;
+      height: 28px;
+      padding: 0 12px;
+      border: 0;
+      border-radius: calc(var(--radius-sm) - 2px);
+      background: transparent;
+      color: var(--color-text-secondary);
+      font-size: var(--text-caption-size) !important;
       font-weight: var(--w-medium);
       cursor: pointer;
+      white-space: nowrap;
       transition:
         background var(--dur-fast) var(--ease-standard),
-        color var(--dur-fast) var(--ease-standard),
-        box-shadow var(--dur-fast) var(--ease-standard);
+        color var(--dur-fast) var(--ease-standard);
+
+      &:hover:not(:disabled) {
+        color: var(--color-text-primary);
+      }
+
+      &.sl-ldb-upload-mode--active {
+        background: rgba(255, 255, 255, 0.14);
+        color: var(--color-text-primary);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  }
+
+  .sl-ldb-file-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .sl-ldb-dropzone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: 30px var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--accent-tint-bg);
+    box-shadow: inset 0 0 0 1.5px var(--hairline);
+    text-align: center;
+    cursor: pointer;
+    transition:
+      background var(--dur-fast) var(--ease-standard),
+      box-shadow var(--dur-fast) var(--ease-standard),
+      transform 0.12s ease;
+
+    &:hover {
+      background: var(--accent-tint-bg-hover);
+      box-shadow: inset 0 0 0 1.5px var(--hairline-strong);
+    }
+
+    &:active {
+      transform: scale(0.995);
+    }
+
+    &.sl-ldb-dropzone--dragging {
+      background: var(--accent-tint-bg-hover);
+      box-shadow:
+        inset 0 0 0 2px rgba(255, 255, 255, 0.6),
+        0 0 0 4px rgba(255, 255, 255, 0.06);
+    }
+
+    &.sl-ldb-dropzone--busy {
+      pointer-events: none;
+      opacity: 0.75;
+    }
+
+    .sl-ldb-dropzone-icon {
+      display: inline-flex;
+      color: var(--color-text-primary);
+      opacity: 0.85;
+    }
+
+    .sl-ldb-dropzone-title {
+      font-size: var(--text-body-size) !important;
+      font-weight: var(--w-semibold);
+      color: var(--color-text-primary);
+    }
+
+    .sl-ldb-dropzone-sub {
+      font-size: var(--text-caption-size) !important;
+      color: var(--color-text-secondary);
       max-width: 100%;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-
-      &:hover {
-        background: var(--accent-tint-bg-hover);
-        box-shadow: inset 0 0 0 1px var(--hairline-strong);
-      }
     }
   }
 
-  .sl-ldb-upload-mode-section {
-    display: flex;
-    gap: var(--space-3);
-
-    .sl-ldb-upload-mode-card {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 6px;
-      padding: 16px 18px;
-      border-radius: var(--radius-md);
-      background: var(--accent-tint-bg);
-      box-shadow: inset 0 0 0 1px var(--hairline);
-      cursor: pointer;
-      text-align: left;
-      transition:
-        background 0.18s var(--ease-standard),
-        box-shadow 0.18s var(--ease-standard),
-        transform 0.12s ease;
-      border: 0;
-
-      &:hover {
-        background: var(--accent-tint-bg-hover);
-        box-shadow: inset 0 0 0 1px var(--hairline-strong);
-      }
-
-      &:active {
-        transform: scale(0.99);
-      }
-
-      /* Active — solid accent edge instead of a heavy fill. The selected
-         card stays calm; the unselected card dims to give the choice
-         visual weight. */
-      &.sl-ldb-upload-mode-card--active {
-        background: var(--accent-tint-bg-hover);
-        box-shadow:
-          inset 0 0 0 1.5px rgba(255, 255, 255, 0.6),
-          0 0 0 4px rgba(255, 255, 255, 0.06);
-
-        .sl-ldb-upload-mode-title {
-          color: var(--color-text-primary);
-        }
-      }
-
-      .sl-ldb-upload-mode-title {
-        font-size: var(--text-body-size) !important;
-        font-weight: var(--w-semibold);
-        color: var(--color-text-primary);
-      }
-
-      .sl-ldb-upload-mode-desc {
-        font-size: var(--text-caption-size) !important;
-        font-weight: var(--w-regular);
-        color: var(--color-text-secondary);
-        line-height: 1.4;
-      }
-    }
-
-    /* When one card is selected, fade the other so the choice is obvious. */
-    &:has(.sl-ldb-upload-mode-card--active) {
-      .sl-ldb-upload-mode-card:not(.sl-ldb-upload-mode-card--active) {
-        opacity: 0.5;
-
-        &:hover {
-          opacity: 0.85;
-        }
-      }
-    }
+  .sl-ldb-spinner {
+    animation: sl-ldb-spin 0.8s linear infinite;
   }
+}
 
-  .sl-ldb-upload-actions {
-    display: flex;
-    gap: var(--space-2);
-    justify-content: flex-end;
-    margin-top: var(--space-1);
-
-    /* Match the toolbar's button size — one component, one size. */
-    .sl-ldb-icon-btn {
-      height: 38px;
-      padding: 0 16px;
-      font-size: var(--text-body-size) !important;
-    }
+@keyframes sl-ldb-spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/components/ReactComponents/SettingsPanel/Footer.tsx
+++ b/src/components/ReactComponents/SettingsPanel/Footer.tsx
@@ -1,0 +1,139 @@
+import { useStore } from "@nanostores/react";
+import React, { useEffect, useState } from "react";
+import Session from "../../Global/Session.ts";
+import App from "../../../utils/app.ts";
+import { $spicyLyricsVersion } from "../../../utils/stores.ts";
+
+interface Link {
+  label: string;
+  url: string;
+  /** Platform tint, as an "r, g, b" triplet. Omitted for the neutral treatment. */
+  brand?: string;
+}
+
+const LINKS: Link[] = [
+  { label: "Website", url: "https://spicylyrics.org" },
+  { label: "Discord", url: "https://discord.com/invite/uqgXU5wh8j", brand: "88, 101, 242" },
+  { label: "Ko-fi", url: "https://ko-fi.com/spikerko", brand: "255, 94, 138" },
+];
+
+/** "checking" until the fetch lands; "unknown" if it never does. */
+type UpdateStatus = "checking" | "latest" | "outdated" | "unknown";
+
+interface Version {
+  Major: number;
+  Minor: number;
+  Patch: number;
+}
+
+/** Ordered compare — Minor only decides once Major ties, and Patch once both do. */
+function isNewer(a: Version, b: Version): boolean {
+  if (a.Major !== b.Major) return a.Major > b.Major;
+  if (a.Minor !== b.Minor) return a.Minor > b.Minor;
+  return a.Patch > b.Patch;
+}
+
+function ExternalArrow() {
+  return (
+    <svg
+      className="sl-sp-footer-arrow"
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M2.5 7.5L7.5 2.5M7.5 2.5H3.5M7.5 2.5V6.5"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function Footer() {
+  const version = useStore($spicyLyricsVersion);
+  const build = App.isDev() ? "dev" : "public";
+  const [status, setStatus] = useState<UpdateStatus>("checking");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const latest = await Session.SpicyLyrics.GetLatestVersion();
+        const current = Session.SpicyLyrics.GetCurrentVersion();
+        if (cancelled) return;
+        // Either side missing means the check didn't conclude — saying
+        // "Latest" there would be a guess dressed up as a fact.
+        if (!latest || !current) {
+          setStatus("unknown");
+          return;
+        }
+        setStatus(isNewer(latest, current) ? "outdated" : "latest");
+      } catch {
+        if (!cancelled) setStatus("unknown");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const showStatus = status === "latest" || status === "outdated";
+
+  return (
+    <div className="sl-sp-footer">
+      <div className="sl-sp-footer-links">
+        {LINKS.map(({ label, url, brand }) => (
+          <button
+            key={label}
+            type="button"
+            className={`sl-sp-footer-link${brand ? " sl-sp-footer-link--brand" : ""}`}
+            style={brand ? ({ "--brand": brand } as React.CSSProperties) : undefined}
+            onClick={() => window.open(url, "_blank")}
+          >
+            <span className="sl-sp-footer-link-label">{label}</span>
+            <ExternalArrow />
+          </button>
+        ))}
+      </div>
+
+      <div className="sl-sp-footer-meta">
+        <span className="sl-sp-footer-build">
+          Build: <span className="sl-sp-footer-build-value">{build}</span>
+        </span>
+        <div className="sl-sp-footer-brand">
+          <span className="sl-sp-footer-wordmark">Spicy Lyrics</span>
+          <div className="sl-sp-footer-status-row">
+            {showStatus && (
+              <>
+                <span className={`sl-sp-footer-status sl-sp-footer-status--${status}`}>
+                  {status === "latest" ? "Latest" : "Outdated"}
+                </span>
+                {status === "outdated" && (
+                  <button
+                    type="button"
+                    className="sl-sp-footer-update"
+                    onClick={() => Session.Navigate({ pathname: "/SpicyLyrics/Update" })}
+                  >
+                    Update
+                  </button>
+                )}
+                <span className="sl-sp-footer-sep" aria-hidden="true">
+                  ·
+                </span>
+              </>
+            )}
+            <span className="sl-sp-footer-version">v{version}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReactComponents/SettingsPanel/index.tsx
+++ b/src/components/ReactComponents/SettingsPanel/index.tsx
@@ -4,6 +4,7 @@ import BackgroundSection from "./BackgroundSection.tsx";
 import CacheSection from "./CacheSection.tsx";
 import DeveloperSection from "./DeveloperSection.tsx";
 import ExperimentsSection from "./ExperimentsSection.tsx";
+import Footer from "./Footer.tsx";
 import InterfaceSection from "./InterfaceSection.tsx";
 import LyricsSection from "./LyricsSection.tsx";
 import PlaybackSection from "./PlaybackSection.tsx";
@@ -43,6 +44,8 @@ export default function SettingsPanel({ onOpenExperiments }: { onOpenExperiments
       />
       <DeveloperSection query={query} sectionFilter={sectionFilter} />
       <CacheSection query={query} sectionFilter={sectionFilter} />
+
+      <Footer />
     </div>
   );
 }

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -227,6 +227,13 @@
   display: inline-block;
 }
 
+/* A letter that is just whitespace collapses to a 0px inline-block, which glues
+   multi-word syllables together. Keep the space rendered and give it a floor. */
+#SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letter.SpaceLetter {
+  white-space: pre;
+  min-width: 0.3ch;
+}
+
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active,
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .word,
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line.Active .letter,
@@ -596,12 +603,29 @@
   transform: translateY(calc(var(--DefaultLyricsSize) * 0)) !important;
 } */
 
+/* Exp_DuetLinePadding — how far a duet line is inset on the side it leans away
+   from. On, the inset is wide enough that the two voices read as separate
+   columns; off, duet lines keep the same slight padding every other line gets. */
+#SpicyLyricsPage.SpicyRenderer
+  .LyricsContainer
+  .LyricsContent
+  .SpicyLyricsScrollContainer.HasDuetLines {
+  --DuetLineInset: 5cqw;
+}
+
+#SpicyLyricsPage.SpicyRenderer.Exp_DuetLinePadding
+  .LyricsContainer
+  .LyricsContent
+  .SpicyLyricsScrollContainer.HasDuetLines {
+  --DuetLineInset: 15cqw;
+}
+
 #SpicyLyricsPage.SpicyRenderer
   .LyricsContainer
   .LyricsContent
   .SpicyLyricsScrollContainer.HasDuetLines
   .line.OppositeAligned:not(.rtl) {
-  padding-left: 15cqw;
+  padding-left: var(--DuetLineInset);
 }
 
 #SpicyLyricsPage.SpicyRenderer
@@ -609,7 +633,7 @@
   .LyricsContent
   .SpicyLyricsScrollContainer.HasDuetLines
   .line:not(.OppositeAligned, .rtl) {
-  padding-right: 15cqw;
+  padding-right: var(--DuetLineInset);
 }
 
 #SpicyLyricsPage.SpicyRenderer
@@ -617,7 +641,7 @@
   .LyricsContent
   .SpicyLyricsScrollContainer.HasDuetLines.HasRtlLines
   .line.OppositeAligned.rtl {
-  padding-right: 15cqw;
+  padding-right: var(--DuetLineInset);
 }
 
 #SpicyLyricsPage.SpicyRenderer
@@ -625,7 +649,7 @@
   .LyricsContent
   .SpicyLyricsScrollContainer.HasDuetLines.HasRtlLines
   .line.rtl:not(.OppositeAligned) {
-  padding-left: 15cqw;
+  padding-left: var(--DuetLineInset);
 }
 
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .SpicyLyricsScrollContainer:not(.HasDuetLines) .line {

--- a/src/css/Lyrics/main.css
+++ b/src/css/Lyrics/main.css
@@ -93,7 +93,12 @@
     padding-left 0.4s;
   display: flex;
   flex-direction: column;
-  margin-bottom: 45cqh;
+  /* The virtualizer appends a permanent spacer of half the viewport height to the
+     scroll element — that is what actually lets the last line reach the centre.
+     This margin is only the small budget on top of it (centre scrolls add a +30px
+     offset, and the credits block below the lines already contributes height).
+     Anything larger is dead space that can be scrolled into past the credits. */
+  margin-bottom: 6cqh;
   margin-top: 25cqh;
 }
 

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -712,6 +712,187 @@ sl-generic-modal.SpicyLyricsModal .sl-modal-overlay {
       transform: scale(0.97);
     }
   }
+
+  /* ── Footer — links out, build identity in ────────────────────────────
+     Two columns: the actions the user can take on the left, the build's
+     identity (channel, wordmark, version) on the right. One quiet outlined
+     card, so it reads as a plinth under the settings rather than as yet
+     another settings group. */
+  .sl-sp-footer {
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
+    gap: var(--space-5);
+    margin-top: var(--space-6);
+    padding: var(--space-4);
+    border-radius: var(--radius-lg);
+    box-shadow: inset 0 0 0 1px var(--hairline);
+  }
+
+  .sl-sp-footer-links {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--space-2);
+    flex: 1;
+    min-width: 0;
+    max-width: 300px;
+  }
+
+  /* Neutral by default; a platform sets --brand and takes over the tint,
+     the hairline and the label colour. */
+  .sl-sp-footer-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: var(--tap-min);
+    padding: 0 var(--space-3);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    background: var(--accent-tint-bg);
+    color: var(--color-text-primary);
+    box-shadow: inset 0 0 0 1px var(--hairline);
+    font-size: var(--text-body-size) !important;
+    font-weight: var(--w-semibold);
+    letter-spacing: 0.01em;
+    transition:
+      background var(--dur-fast) var(--ease-standard),
+      box-shadow var(--dur-fast) var(--ease-standard),
+      color var(--dur-fast) var(--ease-standard),
+      transform 0.12s ease;
+
+    &:hover {
+      background: var(--accent-tint-bg-hover);
+      box-shadow: inset 0 0 0 1px var(--hairline-strong);
+    }
+
+    &:active {
+      transform: scale(0.985);
+    }
+
+    &.sl-sp-footer-link--brand {
+      background: rgba(var(--brand), 0.14);
+      box-shadow: inset 0 0 0 1px rgba(var(--brand), 0.35);
+      color: rgb(var(--brand));
+
+      &:hover {
+        background: rgba(var(--brand), 0.24);
+        box-shadow: inset 0 0 0 1px rgba(var(--brand), 0.55);
+      }
+    }
+  }
+
+  .sl-sp-footer-arrow {
+    flex-shrink: 0;
+    opacity: 0.7;
+  }
+
+  .sl-sp-footer-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--space-4);
+    text-align: right;
+    /* Takes the room the capped link column leaves, so the wordmark — not a
+       void — is what sits between the buttons and the right edge. */
+    flex: 1;
+    min-width: 0;
+  }
+
+  .sl-sp-footer-build {
+    color: var(--color-text-tertiary);
+    font-size: var(--text-footnote-size) !important;
+    font-weight: var(--w-regular);
+    letter-spacing: 0.01em;
+  }
+
+  .sl-sp-footer-build-value {
+    color: var(--color-text-secondary);
+    font-weight: var(--w-medium);
+  }
+
+  .sl-sp-footer-brand {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+  }
+
+  .sl-sp-footer-wordmark {
+    font-size: clamp(1.6rem, 3.2vw, 2.75rem) !important;
+    font-weight: var(--w-semibold);
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+    color: var(--color-text-primary);
+    white-space: nowrap;
+  }
+
+  .sl-sp-footer-version {
+    font-size: clamp(0.95rem, 1.35vw, 1.2rem) !important;
+    font-weight: var(--w-medium);
+    color: var(--color-text-secondary);
+    letter-spacing: 0.01em;
+  }
+
+  /* Status line under the wordmark: how this build stands against the
+     published one, then the version it actually is. The status is dropped
+     entirely when the check doesn't conclude — no claim beats a wrong one. */
+  .sl-sp-footer-status-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 22px;
+  }
+
+  .sl-sp-footer-status {
+    font-size: clamp(0.95rem, 1.35vw, 1.2rem) !important;
+    font-weight: var(--w-semibold);
+    letter-spacing: 0.01em;
+  }
+
+  .sl-sp-footer-status--latest {
+    color: var(--color-status-success);
+  }
+
+  .sl-sp-footer-status--outdated {
+    color: var(--color-status-warning);
+  }
+
+  .sl-sp-footer-sep {
+    color: var(--color-text-quaternary);
+    font-size: var(--text-body-size) !important;
+  }
+
+  /* Only ever shown next to "Outdated", so it carries the same warning hue
+     rather than competing with it. */
+  .sl-sp-footer-update {
+    border: none;
+    border-radius: var(--radius-pill);
+    padding: 3px 10px;
+    cursor: pointer;
+    background: rgba(255, 195, 120, 0.16);
+    color: var(--color-status-warning);
+    box-shadow: inset 0 0 0 1px rgba(255, 195, 120, 0.35);
+    font-size: var(--text-footnote-size) !important;
+    font-weight: var(--w-semibold);
+    letter-spacing: 0.01em;
+    transition:
+      background var(--dur-fast) var(--ease-standard),
+      box-shadow var(--dur-fast) var(--ease-standard),
+      transform 0.12s ease;
+
+    &:hover {
+      background: rgba(255, 195, 120, 0.26);
+      box-shadow: inset 0 0 0 1px rgba(255, 195, 120, 0.55);
+    }
+
+    &:active {
+      transform: scale(0.96);
+    }
+  }
 }
 
 /* Small offsets — the panel is telling you which way you moved, not putting on

--- a/src/utils/Lyrics/Applyer/Static.ts
+++ b/src/utils/Lyrics/Applyer/Static.ts
@@ -16,6 +16,7 @@ import {
   setRomanizedStatus,
 } from "../lyrics.ts";
 import { CreateLyricsContainer, DestroyAllLyricsContainers } from "./CreateLyricsContainer.ts";
+import { StripZeroWidth } from "./Utils/StripZeroWidth.ts";
 import { initLyricsVirtualizer } from "../LyricsVirtualizer.ts";
 import { ApplyIsByCommunity } from "./Credits/ApplyIsByCommunity.tsx";
 import { ApplyLyricsCredits } from "./Credits/ApplyLyricsCredits.ts";
@@ -78,8 +79,9 @@ export function ApplyStaticLyrics(data: StaticLyricsData, UseRomanized: boolean 
   data.Lines.forEach((line) => {
     const lineElem = document.createElement("div");
 
-    lineElem.textContent =
-      UseRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text;
+    lineElem.textContent = StripZeroWidth(
+      UseRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text
+    );
 
     if (isRtl(line.Text) && !lineElem.classList.contains("rtl")) {
       lineElem.classList.add("rtl");

--- a/src/utils/Lyrics/Applyer/Synced/Line.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Line.ts
@@ -20,6 +20,7 @@ import {
   setRomanizedStatus,
 } from "../../lyrics.ts";
 import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer.ts";
+import { StripZeroWidth } from "../Utils/StripZeroWidth.ts";
 import { initLyricsVirtualizer } from "../../LyricsVirtualizer.ts";
 import { ApplyIsByCommunity } from "../Credits/ApplyIsByCommunity.tsx";
 import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits.ts";
@@ -176,8 +177,9 @@ export function ApplyLineLyrics(data: LyricsData, UseRomanized: boolean = false)
 
   data.Content.forEach((line, index, arr) => {
     const lineElem = document.createElement("div");
-    lineElem.textContent =
-      UseRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text;
+    lineElem.textContent = StripZeroWidth(
+      UseRomanized && line.TransliteratedText !== undefined ? line.TransliteratedText : line.Text
+    );
     lineElem.classList.add("line");
 
     if (isRtl(line.Text) && !lineElem.classList.contains("rtl")) {

--- a/src/utils/Lyrics/Applyer/Synced/Syllable.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Syllable.ts
@@ -21,6 +21,7 @@ import {
   setRomanizedStatus,
 } from "../../lyrics.ts";
 import { CreateLyricsContainer, DestroyAllLyricsContainers } from "../CreateLyricsContainer.ts";
+import { StripZeroWidth } from "../Utils/StripZeroWidth.ts";
 import { initLyricsVirtualizer } from "../../LyricsVirtualizer.ts";
 import { ApplyIsByCommunity } from "../Credits/ApplyIsByCommunity.tsx";
 import { ApplyLyricsCredits } from "../Credits/ApplyLyricsCredits.ts";
@@ -239,17 +240,18 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
 
       const totalDuration = ConvertTime(lead.EndTime) - ConvertTime(lead.StartTime);
 
-      const letterLength = (
+      const leadRenderText = StripZeroWidth(
         UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text
-      ).split("").length;
+      );
 
-      const IfLetterCapable = IsLetterCapable(letterLength, totalDuration) && !isRtl(UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text);
+      const letterLength = leadRenderText.split("").length;
+
+      const IfLetterCapable =
+        letterLength > 0 && IsLetterCapable(letterLength, totalDuration) && !isRtl(leadRenderText);
 
       if (IfLetterCapable) {
         word = document.createElement("div");
-        const letters = (
-          UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text
-        ).split(""); // Split word into individual letters
+        const letters = leadRenderText.split(""); // Split word into individual letters
 
         Emphasize(letters, word, lead);
 
@@ -266,8 +268,7 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
           word.style.transform = `translateY(calc(var(--DefaultLyricsSize) * 0.02))`;
         }
       } else {
-        word.textContent =
-          UseRomanized && lead.TransliteratedText !== undefined ? lead.TransliteratedText : lead.Text;
+        word.textContent = leadRenderText;
 
         if (!$simpleLyricsMode.get()) {
           word.style.setProperty("--gradient-position", `-20%`);
@@ -348,17 +349,18 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
 
           const totalDuration = ConvertTime(bw.EndTime) - ConvertTime(bw.StartTime);
 
-          const letterLength = (
+          const bgRenderText = StripZeroWidth(
             UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text
-          ).split("").length;
+          );
 
-          const IfLetterCapable = IsLetterCapable(letterLength, totalDuration) && !isRtl(UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text);
+          const letterLength = bgRenderText.split("").length;
+
+          const IfLetterCapable =
+            letterLength > 0 && IsLetterCapable(letterLength, totalDuration) && !isRtl(bgRenderText);
 
           if (IfLetterCapable) {
             bwE = document.createElement("div");
-            const letters = (
-              UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text
-            ).split(""); // Split word into individual letters
+            const letters = bgRenderText.split(""); // Split word into individual letters
 
             Emphasize(letters, bwE, bw, true);
 
@@ -375,8 +377,7 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
               bwE.style.transform = `translateY(calc(var(--font-size) * 0.02))`;
             }
           } else {
-            bwE.textContent =
-              UseRomanized && bw.TransliteratedText !== undefined ? bw.TransliteratedText : bw.Text;
+            bwE.textContent = bgRenderText;
 
             if (!$simpleLyricsMode.get()) {
               bwE.style.setProperty("--gradient-position", `0%`);

--- a/src/utils/Lyrics/Applyer/Utils/Emphasize.ts
+++ b/src/utils/Lyrics/Applyer/Utils/Emphasize.ts
@@ -36,6 +36,11 @@ export default function Emphasize(
     letterElem.textContent = letter;
     letterElem.classList.add("letter");
     letterElem.classList.add("Emphasis");
+    // Whitespace inside an inline-block collapses to a 0px box, which glues
+    // multi-word syllables ("Watch this") together. Tag it so CSS can size it.
+    if (letter.trim().length === 0) {
+      letterElem.classList.add("SpaceLetter");
+    }
     const isLastLetter = index === letters.length - 1;
     // Calculate start and end time for each letter
     const letterStartTime = StartTime + index * letterDuration;

--- a/src/utils/Lyrics/Applyer/Utils/StripZeroWidth.ts
+++ b/src/utils/Lyrics/Applyer/Utils/StripZeroWidth.ts
@@ -1,0 +1,19 @@
+// Zero-width characters that carry no visual meaning but still occupy a
+// character slot — they break letter-by-letter emphasis (empty <span>s with
+// their own slice of the word's duration) and add invisible cursor stops.
+//
+// U+200B ZERO WIDTH SPACE, U+200E/U+200F LTR/RTL MARK, U+2060 WORD JOINER,
+// U+FEFF ZERO WIDTH NO-BREAK SPACE (BOM).
+//
+// ZWNJ (U+200C) and ZWJ (U+200D) are deliberately left in: they are
+// meaningful in Arabic/Persian/Indic scripts and in emoji sequences.
+//
+// This is render-only. The parsed/cached lyrics keep their original text so
+// nothing downstream (hashing, transliteration, upload) sees a mutated string.
+const ZeroWidthRegex = /[\u200B\u200E\u200F\u2060\uFEFF]/g;
+
+export function StripZeroWidth(text: string): string {
+  return text.replace(ZeroWidthRegex, "");
+}
+
+export default StripZeroWidth;

--- a/src/utils/Lyrics/Global/Applyer.ts
+++ b/src/utils/Lyrics/Global/Applyer.ts
@@ -8,7 +8,7 @@ import { EmitApply, EmitNotApplyed } from "../Applyer/OnApply.ts";
 import { ApplyStaticLyrics, type StaticLyricsData } from "../Applyer/Static.ts";
 import { ApplyLineLyrics } from "../Applyer/Synced/Line.ts";
 import { ApplySyllableLyrics } from "../Applyer/Synced/Syllable.ts";
-import { ClearLyricsPageContainer, ShowQueueLoader } from "../fetchLyrics.ts";
+import { ClearLyricsPageContainer, ShowQueueLoader, type FetchLyricsResult } from "../fetchLyrics.ts";
 import { ClearLyricsContentArrays, isRomanized } from "../lyrics.ts";
 import { PageContainer } from "../../../components/Pages/PageView.ts";
 import { CleanUpIsByCommunity } from "../Applyer/Credits/ApplyIsByCommunity.tsx";
@@ -38,10 +38,25 @@ export const cleanupApplyLyricsAbortController = () => {
  * Apply lyrics based on their type
  * @param lyrics - The lyrics data to apply
  */
-export default async function ApplyLyrics(lyricsContent: [object | string, number] | null): Promise<void> {
+export default async function ApplyLyrics(lyricsContent: FetchLyricsResult): Promise<void> {
   if (!PageContainer) return;
+  if (!lyricsContent) {
+    setBlurringLastLine(null);
+    return;
+  }
+
+  const [descriptor, _status, requestedUri] = lyricsContent;
+
+  // Fetching is async, so a result can land after the user has already skipped
+  // on. Applying it would paint the previous track's lyrics — or its "no
+  // lyrics" notice — over the new track, and the notice branch below would
+  // stamp the NO_LYRICS sentinel with the new track's uri, making every later
+  // fetch for that track short-circuit to "no lyrics" for good. Drop it and
+  // leave the current track's own apply to do the work.
+  const currentUri = SpotifyPlayer.GetUri();
+  if (requestedUri && currentUri && requestedUri !== currentUri) return;
+
   setBlurringLastLine(null);
-  if (!lyricsContent) return;
 
   cleanupApplyLyricsAbortController()
 
@@ -54,8 +69,6 @@ export default async function ApplyLyrics(lyricsContent: [object | string, numbe
   ClearLyricsPageContainer();
 
   CleanUpIsByCommunity();
-
-  const [descriptor, _status] = lyricsContent;
 
   let noticeContent: string | null = null;
 
@@ -115,7 +128,9 @@ export default async function ApplyLyrics(lyricsContent: [object | string, numbe
     $currentLyricsType.set("None");
 
     if (descriptor === "lyrics-not-found") {
-      const uri = SpotifyPlayer.GetUri() ?? "";
+      // Key the sentinel off the uri the fetch was made for, never off whatever
+      // happens to be playing now — see the staleness check above.
+      const uri = requestedUri ?? currentUri ?? "";
       $currentLyricsData.set(`NO_LYRICS:${uri}`);
     } else {
       $currentLyricsData.set("");

--- a/src/utils/Lyrics/LyricsQueueRetry.ts
+++ b/src/utils/Lyrics/LyricsQueueRetry.ts
@@ -3,7 +3,7 @@ import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
 import Global from "../../components/Global/Global.ts";
 import Logger from "../Logger.ts";
 import ApplyLyrics from "./Global/Applyer.ts";
-import fetchLyrics, { ShowQueueLoader } from "./fetchLyrics.ts";
+import fetchLyrics, { ShowQueueLoader, type FetchLyricsResult } from "./fetchLyrics.ts";
 
 const queueLogger = new Logger("Lyrics Queue Retry");
 
@@ -18,7 +18,7 @@ function computeDelay(attempt: number): number {
   return Math.min(MAX_DELAY_MS, Math.round(scaled));
 }
 
-type FetchResult = [object | string, number] | null;
+type FetchResult = FetchLyricsResult;
 
 // `null` means the fetch was guarded/dropped (an overlapping fetch) — keep
 // waiting. The "lyrics-queued" descriptor means the server is still queuing us.

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -47,7 +47,69 @@ function presentLyrics(lyricsData: any): void {
   $currentlyFetching.set(false);
 }
 
-export default async function fetchLyrics(uri: string): Promise<[object | string, number] | null> {
+/**
+ * A lyrics fetch result: the descriptor (a lyrics payload, or a keyword naming
+ * the notice to show), the HTTP-ish status, and the uri the fetch was made for.
+ * The uri lets ApplyLyrics recognise — and drop — a result that only lands
+ * after the user has already skipped to another track.
+ */
+export type FetchLyricsResult = [object | string, number, string?] | null;
+
+/**
+ * The uri of the fetch currently in flight, or `null`.
+ *
+ * A second request for the SAME uri is de-duplicated — the one already running
+ * will paint. A request for a DIFFERENT uri supersedes it: the older fetch is
+ * left to finish, but its result carries its own uri, so ApplyLyrics drops it
+ * rather than painting the previous track's lyrics (or its "no lyrics" notice)
+ * over the new one.
+ */
+let inFlightUri: string | null = null;
+
+/**
+ * The uri of the most recent fetch request. Unlike `inFlightUri` this is never
+ * cleared, so a fetch that finishes *after* the one that superseded it still
+ * sees that it lost the race.
+ */
+let latestRequestedUri: string | null = null;
+
+/**
+ * True when the fetch for `uri` has been overtaken and its result must not be
+ * shown: a newer fetch for a different track was started, or the player has
+ * already moved on. Presenting it would paint the previous track's lyrics — or
+ * its "no lyrics" notice — over the track now playing, and stamp
+ * `$currentLyricsData` with the wrong track's payload.
+ */
+function isStaleFetch(uri: string): boolean {
+  if (latestRequestedUri !== null && latestRequestedUri !== uri) return true;
+  const currentUri = SpotifyPlayer.GetUri();
+  return currentUri != null && currentUri !== uri;
+}
+
+export default async function fetchLyrics(uri: string): Promise<FetchLyricsResult> {
+  if (inFlightUri === uri) {
+    lyricsLogger.debug("Fetch already in flight for this track, skipping", uri);
+    return null;
+  }
+
+  inFlightUri = uri;
+  latestRequestedUri = uri;
+  $currentlyFetching.set(true);
+
+  try {
+    const result = await runFetchLyrics(uri);
+    // Stamp the result with the uri it was requested for, so a late arrival can
+    // be told apart from a result for the track that's playing now.
+    return result ? [result[0], result[1], uri] : null;
+  } finally {
+    // Only release the lock if we still hold it — a newer fetch may have taken
+    // over while this one was awaiting.
+    if (inFlightUri === uri) inFlightUri = null;
+    $currentlyFetching.set(false);
+  }
+}
+
+async function runFetchLyrics(uri: string): Promise<[object | string, number] | null> {
   lyricsLogger.debug("Fetch requested", uri);
   //if (!PageContainer) return;
   const LyricsContent =
@@ -90,13 +152,6 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
 
   const trackId = uri.split(":")[2];
 
-  if ($currentlyFetching.get()) {
-    $currentlyFetching.set(false);
-    return null;
-  }
-
-  $currentlyFetching.set(true);
-
   if (LyricsContent) {
     LyricsContent.classList.add("HiddenTransitioned");
   }
@@ -133,6 +188,7 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
   const localLyric = await LocalLyricsManager.get(uri);
   if (localLyric) {
     const lyricsData = { ...localLyric, uri };
+    if (isStaleFetch(uri)) return [lyricsData, 200];
     $currentLyricsData.set(JSON.stringify(lyricsData));
     presentLyrics(lyricsData);
     return [lyricsData, 200];
@@ -159,6 +215,7 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
         // re-fetch checks (which match on uri) recognise it — older cache
         // entries predate the uri field.
         const lyricsFromCache = { ...(lyricsFromCacheRes ?? {}), uri };
+        if (isStaleFetch(uri)) return [{ ...lyricsFromCache, fromCache: true }, 200];
         $currentLyricsData.set(JSON.stringify(lyricsFromCache));
         presentLyrics(lyricsFromCache);
         return [{ ...lyricsFromCache, fromCache: true }, 200];
@@ -248,8 +305,9 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     // Stamp the uri so every match downstream (saved-data, re-fetch, cache)
     // keys off the stable uri instead of the API-supplied id.
     lyrics.uri = uri;
-    $currentLyricsData.set(JSON.stringify(lyrics));
 
+    // The request already completed, so cache it either way — even if the user
+    // has skipped on, the next play of this track gets a cache hit.
     if (LyricsStore) {
       try {
         await LyricsStore.SetItem(trackId, lyrics);
@@ -258,6 +316,9 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
       }
     }
 
+    if (isStaleFetch(uri)) return [{ ...lyrics, fromCache: false }, 200];
+
+    $currentLyricsData.set(JSON.stringify(lyrics));
     presentLyrics(lyrics);
     return [{ ...lyrics, fromCache: false }, 200];
   } catch (error) {

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -15,7 +15,7 @@ const lyricsLogger = new Logger("Lyrics Pipeline");
 const lyricsCacheLogger = new Logger("Lyrics Cache");
 
 // recently updated key structure - changed name
-export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore_g1", 1, {
+export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore_g1", 2, {
   Unit: "Days",
   Duration: 3,
 }, isDev as true);

--- a/src/utils/Lyrics/manager/index.ts
+++ b/src/utils/Lyrics/manager/index.ts
@@ -30,15 +30,12 @@ async function get(uri: string): Promise<any | null> {
       return null;
     }
 
-    const parsed = await ParseTTML(data);
-    if (parsed == null || typeof parsed !== "object") {
+    const parsed = ParseTTML(data);
+    if (parsed == null) {
       return null;
     }
 
-    const result = "Result" in parsed ? (parsed as Record<string, unknown>).Result : undefined;
-    return (result && typeof result === "object" && result !== null)
-      ? Object.assign({}, result as object, { source: "ldb" })
-      : null;
+    return Object.assign({}, parsed, { source: "ldb" });
   } catch (error) {
     logCaught("get", error, { uri });
     return null;

--- a/src/utils/Lyrics/manager/parseTTML.ts
+++ b/src/utils/Lyrics/manager/parseTTML.ts
@@ -1,38 +1,6 @@
-import { Query } from "../../API/Query";
+import { parseTTML, type ParsedTTMLLyrics } from "../ttml/parser";
 
-export async function ParseTTML(ttml: string): Promise<any | null> {
-  try {
-    const query = await Query([
-      {
-        operation: "parseTTML",
-        variables: {
-          ttml,
-        },
-      },
-    ]);
-    const queryResult = query.get("0");
-    if (!queryResult) {
-      return null;
-    }
-
-    if (queryResult.httpStatus !== 200) {
-      return null;
-    }
-
-    if (!queryResult.data) {
-      return null;
-    }
-
-    if (queryResult.format !== "json") {
-      return null;
-    }
-
-    if (queryResult.data.error) {
-      return null;
-    }
-
-    return queryResult.data;
-  } catch (error) {
-    return null;
-  }
+export function ParseTTML(ttml: unknown): ParsedTTMLLyrics | null {
+  if (typeof ttml !== "string") return null;
+  return parseTTML(ttml);
 }

--- a/src/utils/Lyrics/ttml/parser.ts
+++ b/src/utils/Lyrics/ttml/parser.ts
@@ -1,0 +1,1169 @@
+import { XMLParser } from 'fast-xml-parser';
+import Logger from '../../Logger.ts';
+
+const ttmlLogger = new Logger("TTML Parser");
+
+type TtmlTime = string | number;
+type TtmlText = string | number | boolean;
+
+export interface TtmlSpan {
+  '#text'?: TtmlText;
+  begin?: TtmlTime;
+  end?: TtmlTime;
+  'ttm:role'?: string;
+  'itunes:key'?: string;
+  span?: TtmlSpanNode | TtmlSpanNode[];
+}
+
+export type TtmlSpanNode = TtmlSpan | string;
+
+export interface TtmlP {
+  '#text'?: TtmlText;
+  begin?: TtmlTime;
+  end?: TtmlTime;
+  'ttm:agent'?: string;
+  'itunes:key'?: string;
+  span?: TtmlSpanNode | TtmlSpanNode[];
+}
+
+export type TtmlPNode = TtmlP | string;
+
+export interface TtmlDiv {
+  begin?: TtmlTime;
+  end?: TtmlTime;
+  'itunes:songPart'?: string;
+  'ttm:agent'?: string;
+  p?: TtmlPNode | TtmlPNode[];
+}
+
+export interface TtmlAgent {
+  type?: string;
+  'xml:id'?: string;
+}
+
+export interface TtmlTransliterationEntry {
+  for?: string;
+  span?: TtmlSpanNode | TtmlSpanNode[];
+}
+
+export interface TtmlTransliterationBlock {
+  text?: TtmlTransliterationEntry | TtmlTransliterationEntry[];
+}
+
+export interface TtmlITunesMetadata {
+  songwriters?: { songwriter?: string | string[] };
+  transliterations?: {
+    transliteration?: TtmlTransliterationBlock | TtmlTransliterationBlock[];
+  };
+}
+
+export interface TtmlDocument {
+  tt?: {
+    'itunes:timing'?: string;
+    head?: {
+      metadata?: {
+        'ttm:agent'?: TtmlAgent | TtmlAgent[];
+        iTunesMetadata?: TtmlITunesMetadata | TtmlITunesMetadata[];
+      };
+    };
+    body?: {
+      'ttm:agent'?: string;
+      div?: TtmlDiv | TtmlDiv[];
+      p?: TtmlPNode | TtmlPNode[];
+    };
+  };
+}
+
+export type TTMLLyricsType = 'Static' | 'Line' | 'Syllable';
+
+export interface ParsedStaticLine {
+  Text: string;
+  TransliteratedText?: string;
+  TranslatedText?: string;
+  HasTransliterations?: boolean;
+  HasTranslations?: boolean;
+}
+
+export interface ParsedLineVocal {
+  Type: 'Vocal';
+  OppositeAligned: boolean;
+  Text: string | undefined;
+  StartTime: number | undefined;
+  EndTime: number | undefined;
+  TransliteratedText?: string;
+  TranslatedText?: string;
+  HasTransliterations?: boolean;
+  HasTranslations?: boolean;
+}
+
+export interface ParsedSyllable {
+  Text: string;
+  TransliteratedText?: string;
+  IsPartOfWord: boolean;
+  StartTime: number | undefined;
+  EndTime: number | undefined;
+}
+
+export interface ParsedVocalGroup {
+  Syllables: ParsedSyllable[];
+  StartTime: number | undefined;
+  EndTime: number | undefined;
+  TransliteratedText?: string;
+  TranslatedText?: string;
+  HasTransliterations?: boolean;
+  HasTranslations?: boolean;
+}
+
+export interface ParsedSyllableVocal {
+  Type: 'Vocal';
+  OppositeAligned: boolean;
+  Lead: ParsedVocalGroup;
+  Background?: ParsedVocalGroup[];
+  HasTransliterations?: boolean;
+  HasTranslations?: boolean;
+}
+
+interface ParsedLyricsBase {
+  SongWriters?: string[];
+  HasTransliterations?: boolean;
+  HasTranslations?: boolean;
+}
+
+export interface ParsedStaticLyrics extends ParsedLyricsBase {
+  Type: 'Static';
+  Lines: ParsedStaticLine[];
+}
+
+export interface ParsedLineLyrics extends ParsedLyricsBase {
+  Type: 'Line';
+  StartTime: number | undefined;
+  EndTime: number | undefined;
+  Content: ParsedLineVocal[];
+}
+
+export interface ParsedSyllableLyrics extends ParsedLyricsBase {
+  Type: 'Syllable';
+  StartTime: number | undefined;
+  EndTime?: number | undefined;
+  Content: ParsedSyllableVocal[];
+}
+
+export type ParsedTTMLLyrics =
+  | ParsedStaticLyrics
+  | ParsedLineLyrics
+  | ParsedSyllableLyrics;
+
+type ParsedRootItem = ParsedStaticLine | ParsedLineVocal | ParsedSyllableVocal;
+
+interface TrackAgent {
+  Type: string | undefined;
+  Id: string | undefined;
+  OppositeAligned: boolean;
+}
+
+interface TransliterationSpan {
+  begin: TtmlTime;
+  end: TtmlTime;
+  beginSeconds: number | undefined;
+  endSeconds: number | undefined;
+  text: string;
+}
+
+/**
+ * One <text for="..."> entry, split by which vocal it transliterates: the
+ * entry's own timed spans mirror the lead, and spans nested under an
+ * `<span ttm:role="x-bg">` wrapper mirror that line's background vocal.
+ */
+interface TransliterationLine {
+  spans: TransliterationSpan[];
+  background: TransliterationSpan[];
+}
+
+type TransliterationMap = Map<string, TransliterationLine>;
+
+interface RoleTexts {
+  roman: string | undefined;
+  translation: string | undefined;
+}
+
+const isSpanObject = (span: TtmlSpanNode | undefined): span is TtmlSpan =>
+  typeof span === 'object' && span !== null;
+
+/** A span carrying actual lyrics text — anything with a ttm:role is metadata. */
+const isVocalSpan = (span: TtmlSpanNode | undefined): span is TtmlSpan =>
+  isSpanObject(span) && !span['ttm:role'];
+
+const toArray = <T>(value: T | T[] | undefined | null): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+
+const isSupportedLyricsType = (value: unknown): value is TTMLLyricsType =>
+  value === 'Static' || value === 'Line' || value === 'Syllable';
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const decodeXmlEntities = (str: string): string => {
+  if (str.indexOf("&") === -1) return str;
+
+  const named: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+  };
+
+  return str.replace(
+    /&(?:#x([0-9a-fA-F]{1,6})|#([0-9]{1,7})|([a-zA-Z][a-zA-Z0-9]{0,31}));/g,
+    (
+      match: string,
+      hex: string | undefined,
+      dec: string | undefined,
+      name: string | undefined,
+    ) => {
+      if (name !== undefined) {
+        return Object.prototype.hasOwnProperty.call(named, name)
+          ? named[name]
+          : match;
+      }
+
+      const digits = hex ?? dec;
+      if (digits === undefined) return match;
+
+      const code = hex !== undefined ? parseInt(hex, 16) : parseInt(digits, 10);
+
+      if (!Number.isFinite(code)) return match;
+      if (code <= 0 || code > 0x10ffff) return match;
+      if (code >= 0xd800 && code <= 0xdfff) return match;
+      if (code === 0x09 || code === 0x0a || code === 0x0d) {
+        return String.fromCodePoint(code);
+      }
+      if (code < 0x20) return match;
+
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return match;
+      }
+    },
+  );
+};
+
+/**
+ * Reads a node's text content. The parser runs with processEntities: false, so
+ * every text value has to be decoded here — otherwise `&amp;` and friends reach
+ * the lyrics verbatim. Decoding happens at extraction, before any trimming or
+ * whitespace/punctuation checks, so those see real characters.
+ */
+const readText = (value: TtmlText | undefined): string =>
+  value === undefined || value === null ? '' : decodeXmlEntities(value.toString());
+
+const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '',
+    trimValues: false,
+    parseTagValue: false,
+    parseAttributeValue: false,
+    allowBooleanAttributes: false,
+    processEntities: false,
+});
+
+/**
+ * fast-xml-parser collapses every text node of an element into a single
+ * `#text`, so the whitespace *between* two sibling spans is lost — and that
+ * whitespace is exactly what tells "Ma"+"ma" (one word) from "Ma" + "ma" (two).
+ * The only place that information survives is the raw XML, so adjacency is
+ * recovered by locating each span's start tag there.
+ *
+ * The lookup walks a cursor forward through the document instead of searching
+ * from index 0 every time: transliteration spans in <head> mirror the lyric
+ * timings exactly, so a search from the start would keep matching those and
+ * report adjacency for the wrong element (and cost O(n) per syllable).
+ */
+interface AdjacencyScanner {
+  /** True when the span's closing tag is immediately followed by another tag. */
+  isImmediatelyFollowedByTag(begin: TtmlTime | undefined, end: TtmlTime | undefined): boolean;
+}
+
+const createAdjacencyScanner = (xml: string): AdjacencyScanner => {
+  const bodyIndex = xml.indexOf('<body');
+  const searchStart = bodyIndex === -1 ? 0 : bodyIndex;
+  let cursor = searchStart;
+  const patterns = new Map<string, RegExp | null>();
+
+  const getPattern = (begin: string, end: string): RegExp | null => {
+    const key = `${begin} ${end}`;
+    if (patterns.has(key)) return patterns.get(key) ?? null;
+    // Bounded so a pathological document can't grow the cache without limit.
+    if (patterns.size > 4096) patterns.clear();
+
+    let pattern: RegExp | null = null;
+    try {
+      const b = escapeRegExp(begin);
+      const e = escapeRegExp(end);
+      // Attribute order and quote style both vary between TTML producers.
+      pattern = new RegExp(
+        `<span\\b[^>]*\\bbegin\\s*=\\s*(["'])${b}\\1[^>]*\\bend\\s*=\\s*(["'])${e}\\2[^>]*>` +
+          `|<span\\b[^>]*\\bend\\s*=\\s*(["'])${e}\\3[^>]*\\bbegin\\s*=\\s*(["'])${b}\\4[^>]*>`,
+        'g',
+      );
+    } catch (error) {
+      ttmlLogger.debug('Failed to build span lookup pattern', (error as Error)?.message);
+      pattern = null;
+    }
+
+    patterns.set(key, pattern);
+    return pattern;
+  };
+
+  const execFrom = (pattern: RegExp, from: number): RegExpExecArray | null => {
+    pattern.lastIndex = from < 0 ? 0 : from;
+    return pattern.exec(xml);
+  };
+
+  return {
+    isImmediatelyFollowedByTag(begin, end) {
+      if (begin == null || end == null || begin === '' || end === '') return false;
+
+      const pattern = getPattern(String(begin), String(end));
+      if (!pattern) return false;
+
+      // Forward from the cursor first; fall back to a full body scan for
+      // documents whose parsed order doesn't match document order.
+      const match = execFrom(pattern, cursor) ?? execFrom(pattern, searchStart);
+      if (!match) return false;
+
+      const tagEnd = match.index + match[0].length;
+      cursor = tagEnd;
+
+      // charAt() past the end returns '', so no explicit bounds check needed.
+      if (match[0].endsWith('/>')) return xml.charAt(tagEnd) === '<';
+
+      const closingIndex = xml.indexOf('</span>', tagEnd);
+      if (closingIndex === -1) return false;
+
+      return xml.charAt(closingIndex + '</span>'.length) === '<';
+    },
+  };
+};
+
+/** Divs, tolerating documents that hang <p> straight off <body>. */
+const getDivs = (ttml: TtmlDocument): TtmlDiv[] => {
+  const body = ttml?.tt?.body;
+  if (!body) return [];
+  const divs = toArray(body.div).filter((div): div is TtmlDiv => div != null && typeof div === 'object');
+  if (divs.length > 0) return divs;
+  if (body.p != null) return [{ p: body.p }];
+  return [];
+};
+
+interface SyllableBuildInput {
+  /** Sibling nodes in document order — role spans included, they gate adjacency. */
+  siblings: TtmlSpanNode[];
+  transliterations: TransliterationSpan[] | null | undefined;
+  stripParentheses: boolean;
+  scanner: AdjacencyScanner;
+}
+
+function buildSyllables({
+  siblings,
+  transliterations,
+  stripParentheses,
+  scanner,
+}: SyllableBuildInput): ParsedSyllable[] {
+  const syllables: ParsedSyllable[] = [];
+  const clean = (value: string): string =>
+    stripParentheses ? value.trim().replace(/[()]/g, '').trim() : value.trim();
+
+  siblings.forEach((node, index) => {
+    if (!isVocalSpan(node)) return;
+
+    // Called for every vocal span, including skipped ones, to keep the
+    // scanner's cursor aligned with document order.
+    const closingTagIsAdjacent = scanner.isImmediatelyFollowedByTag(node.begin, node.end);
+
+    const rawText = readText(node['#text']);
+    if (rawText === '') return;
+
+    const text = clean(rawText);
+    if (text === '') return;
+
+    let isPartOfWord = false;
+    const nextNode = siblings[index + 1];
+    // Only a following *vocal* span can continue a word; a trailing x-bg or
+    // x-translation sibling means this syllable ends the word.
+    if (closingTagIsAdjacent && isVocalSpan(nextNode)) {
+      const nextText = readText(nextNode['#text']);
+      const endsWithComma = rawText.trim().endsWith(',');
+      const endsWithWhitespace = /\s$/.test(rawText);
+      if (!/^\s/.test(nextText) && !endsWithComma && !endsWithWhitespace) {
+        isPartOfWord = true;
+      }
+    }
+
+    const translit = findTransliteratedText(transliterations, node.begin, node.end);
+    const translitText = translit ? clean(translit.text) : '';
+
+    syllables.push({
+      Text: text,
+      ...(translitText !== '' ? { TransliteratedText: translitText } : {}),
+      IsPartOfWord: isPartOfWord,
+      StartTime: convertTimeToSeconds(node.begin),
+      EndTime: convertTimeToSeconds(node.end),
+    });
+  });
+
+  return syllables;
+}
+
+export function parseTTML(ttmlInput: string): ParsedTTMLLyrics | null {
+  if (typeof ttmlInput !== 'string' || ttmlInput.trim() === '') {
+    ttmlLogger.warn('Refusing to parse empty or non-string TTML input');
+    return null;
+  }
+
+  try {
+    return convertTTML(ttmlInput);
+  } catch (error) {
+    ttmlLogger.error(
+      'Unexpected error while converting TTML',
+      (error as Error)?.message ?? String(error),
+    );
+    return null;
+  }
+}
+
+function convertTTML(ttmlInput: string): ParsedTTMLLyrics | null {
+  let ttml: TtmlDocument;
+  try {
+    ttml = parser.parse(ttmlInput) as TtmlDocument;
+  } catch (parseError) {
+    ttmlLogger.error('Failed to parse TTML XML', (parseError as Error)?.message);
+    return null;
+  }
+
+  if (!ttml?.tt || typeof ttml.tt !== 'object' || !ttml.tt.body || typeof ttml.tt.body !== 'object') {
+    ttmlLogger.warn('Parsed XML is not a TTML document, rejecting');
+    return null;
+  }
+
+  const divs = getDivs(ttml);
+  if (divs.length === 0) {
+    ttmlLogger.warn('TTML body contains no usable <div>/<p> content, rejecting');
+    return null;
+  }
+
+  const timing = ttml.tt['itunes:timing'];
+
+  let lyricsType: string;
+  if (timing === 'None') {
+    lyricsType = 'Static';
+  } else if (timing === 'Word') {
+    lyricsType = 'Syllable';
+  } else if (timing === undefined) {
+    lyricsType = inferLyricsType(ttml);
+    ttmlLogger.debug('No itunes:timing attribute, inferred lyrics type from structure', { inferred: lyricsType });
+  } else {
+    lyricsType = timing;
+  }
+
+  if (!isSupportedLyricsType(lyricsType)) {
+    ttmlLogger.warn('Unknown itunes:timing value, rejecting', { timing });
+    return null;
+  }
+
+  ttmlLogger.debug(`Determined lyrics type: ${lyricsType}`);
+
+  const SongWriters = GetSongWriters(ttml);
+  const Transliterations = GetTransliterations(ttml);
+
+  const base: ParsedLyricsBase = SongWriters ? { SongWriters } : {};
+
+  let lyricsJSON: ParsedTTMLLyrics;
+
+  const Agents = ttml.tt.head?.metadata?.["ttm:agent"];
+  const PostAgents = toArray(Agents).filter((agent): agent is TtmlAgent => agent != null && typeof agent === 'object');
+
+  const isOppositeAlignedAgent = (agent: TtmlAgent): boolean => {
+    const agentId = agent["xml:id"];
+    // v1 is always the main vocal track
+    if (agentId === "v1") return false;
+    // v2000 and v2 are usually OppositeAligned
+    if (agentId === "v2000" || agentId === "v2") return true;
+    return false;
+  };
+
+  const TrackAgents: TrackAgent[] = PostAgents.map((agent) => {
+    return {
+      Type: agent.type,
+      Id: agent["xml:id"],
+      OppositeAligned: isOppositeAlignedAgent(agent)
+    }
+  });
+
+  switch (lyricsType) {
+    case 'Static': {
+      ttmlLogger.debug('Processing static lyrics');
+      const staticLyrics: ParsedStaticLyrics = { ...base, Type: 'Static', Lines: [] };
+      divs.forEach((div) => {
+        if (div["itunes:songPart"] === "Instrumental" || div["itunes:songPart"] === "Outro") return;
+        const divp = toArray(div.p);
+        divp.forEach((p) => {
+          if (p == null) return;
+          const text = getLineText(p) ?? "";
+          const line: ParsedStaticLine = {
+            Text: text.trim(),
+          };
+
+          // Static never carries iTunesMetadata transliterations; only inline
+          // x-roman / x-translation spans apply, placed at line level.
+          const roles = getInlineRoleTexts(p);
+          if (roles.roman !== undefined && roles.roman.trim() !== "") {
+            line.TransliteratedText = roles.roman.trim();
+            line.HasTransliterations = true;
+          }
+          if (roles.translation !== undefined && roles.translation.trim() !== "") {
+            line.TranslatedText = roles.translation.trim();
+            line.HasTranslations = true;
+          }
+
+          staticLyrics.Lines.push(line);
+        });
+      });
+      lyricsJSON = staticLyrics;
+      break;
+    }
+
+    case 'Line': {
+      ttmlLogger.debug('Processing line-synced lyrics');
+
+      const buildLine = (p: TtmlPNode): ParsedLineVocal => {
+        const pSpans = p != null && typeof p === 'object' && p.span ? toArray(p.span) : [];
+        const vocalSpans = pSpans.filter(isVocalSpan);
+        const begin = (typeof p === 'object' ? p?.begin : undefined) ?? vocalSpans[0]?.begin;
+        const end = (typeof p === 'object' ? p?.end : undefined) ?? vocalSpans[vocalSpans.length - 1]?.end;
+
+        const line: ParsedLineVocal = {
+          Type: 'Vocal',
+          OppositeAligned: false,
+          Text: getLineText(p),
+          StartTime: convertTimeToSeconds(begin),
+          EndTime: convertTimeToSeconds(end),
+        };
+
+        const roles = getInlineRoleTexts(p);
+        const lineKey = p && typeof p === 'object' ? p['itunes:key'] : undefined;
+        const itmTranslit = lineKey ? Transliterations?.get(lineKey)?.spans : undefined;
+
+        let translit: string | undefined;
+        if (itmTranslit && itmTranslit.length > 0) {
+          translit = itmTranslit.map((s) => s.text).join('');
+        } else if (roles.roman !== undefined) {
+          translit = roles.roman;
+        }
+        if (translit !== undefined && translit.trim() !== '') {
+          line.TransliteratedText = translit.trim();
+          line.HasTransliterations = true;
+        }
+        if (roles.translation !== undefined && roles.translation.trim() !== '') {
+          line.TranslatedText = roles.translation.trim();
+          line.HasTranslations = true;
+        }
+        return line;
+      };
+
+      const lineLyrics: ParsedLineLyrics = {
+        ...base,
+        Type: 'Line',
+        StartTime: undefined,
+        EndTime: undefined,
+        Content: [],
+      };
+
+      const timedDivs = divs.filter((div) => div["itunes:songPart"] !== "Instrumental");
+      lineLyrics.Content = timedDivs.flatMap((div) =>
+        toArray(div.p).filter((p) => p != null).map(buildLine),
+      );
+
+      const firstDiv = timedDivs[0] ?? divs[0];
+      const lastDiv = timedDivs[timedDivs.length - 1] ?? divs[divs.length - 1];
+      lineLyrics.StartTime =
+        convertTimeToSeconds(firstDiv?.begin) ?? lineLyrics.Content[0]?.StartTime;
+      lineLyrics.EndTime =
+        convertTimeToSeconds(lastDiv?.end) ??
+        lineLyrics.Content[lineLyrics.Content.length - 1]?.EndTime;
+
+      lyricsJSON = lineLyrics;
+      break;
+    }
+
+    case 'Syllable': {
+      ttmlLogger.debug('Processing syllable-synced lyrics');
+      const scanner = createAdjacencyScanner(ttmlInput);
+      const firstDiv = divs[0];
+      let skippedEmptyLines = 0;
+
+      const syllableLyrics: ParsedSyllableLyrics = {
+        ...base,
+        Type: 'Syllable',
+        StartTime: convertTimeToSeconds(firstDiv?.begin),
+        Content: [],
+      };
+
+      divs.forEach((div) => {
+        if (div["itunes:songPart"] === "Instrumental") return;
+
+        const ps = toArray(div.p);
+        ps.forEach((p) => {
+          if (!p || typeof p !== 'object') return;
+          const pAgentId = p["ttm:agent"] || div["ttm:agent"] || ttml.tt.body["ttm:agent"];
+          const trackAgent = pAgentId ? TrackAgents.find((a) => a.Id === pAgentId) : undefined;
+          const isOpposite = trackAgent ? trackAgent.OppositeAligned : false;
+          const lineKey = p['itunes:key'];
+          const lineTranslitEntry = lineKey ? Transliterations?.get(lineKey) : undefined;
+          const lineTranslit = lineTranslitEntry?.spans;
+
+          const vocal: ParsedSyllableVocal = {
+            Type: 'Vocal',
+            OppositeAligned: isOpposite,
+            Lead: {
+              Syllables: [],
+              StartTime: convertTimeToSeconds(p.begin),
+              EndTime: convertTimeToSeconds(p.end),
+            },
+          };
+
+          const pSpans = toArray(p.span);
+
+          vocal.Lead.Syllables = buildSyllables({
+            siblings: pSpans,
+            transliterations: lineTranslit,
+            stripParentheses: false,
+            scanner,
+          });
+
+          // A word-timed document can still contain a line-timed <p> with no
+          // syllable spans — keep its text instead of emitting a blank line.
+          if (vocal.Lead.Syllables.length === 0) {
+            const fallbackText = (getLineText(p) ?? '').trim();
+            if (fallbackText !== '') {
+              vocal.Lead.Syllables.push({
+                Text: fallbackText,
+                IsPartOfWord: false,
+                StartTime: convertTimeToSeconds(p.begin),
+                EndTime: convertTimeToSeconds(p.end),
+              });
+            }
+          }
+
+          const firstSyllable = vocal.Lead.Syllables[0];
+          const lastSyllable = vocal.Lead.Syllables[vocal.Lead.Syllables.length - 1];
+          if (vocal.Lead.StartTime === undefined) vocal.Lead.StartTime = firstSyllable?.StartTime;
+          if (vocal.Lead.EndTime === undefined) vocal.Lead.EndTime = lastSyllable?.EndTime;
+
+          const leadRoles = getInlineRoleTexts(p);
+          if (leadRoles.roman !== undefined && leadRoles.roman.trim() !== '') {
+            vocal.Lead.TransliteratedText = leadRoles.roman.trim();
+          }
+          if (leadRoles.translation !== undefined && leadRoles.translation.trim() !== '') {
+            vocal.Lead.TranslatedText = leadRoles.translation.trim();
+            vocal.HasTranslations = true;
+          }
+          if (
+            vocal.Lead.TransliteratedText !== undefined ||
+            vocal.Lead.Syllables.some((s) => s.TransliteratedText !== undefined)
+          ) {
+            vocal.HasTransliterations = true;
+          }
+
+          const filteredBgSpans = pSpans.filter(
+            (span): span is TtmlSpan => isSpanObject(span) && span['ttm:role'] === 'x-bg',
+          );
+
+          if (filteredBgSpans.length > 0) {
+            const backgrounds: ParsedVocalGroup[] = [];
+
+            filteredBgSpans.forEach((bgSpan) => {
+              const bgLineKey = bgSpan['itunes:key'];
+              const bgKeyTranslit = bgLineKey ? Transliterations?.get(bgLineKey) : undefined;
+              const bgLineTranslit = pickBackgroundTransliterations(bgKeyTranslit, lineTranslitEntry);
+
+              const bgSpanSpans = toArray(bgSpan.span);
+              const bgVocalSpans = bgSpanSpans.filter(isVocalSpan);
+              const bgRoles = extractRoleTexts(bgSpanSpans);
+
+              const bgVocal: ParsedVocalGroup = {
+                Syllables: buildSyllables({
+                  siblings: bgSpanSpans,
+                  transliterations: bgLineTranslit,
+                  stripParentheses: true,
+                  scanner,
+                }),
+                StartTime: undefined,
+                EndTime: undefined,
+              };
+
+              bgVocal.StartTime =
+                convertTimeToSeconds(bgVocalSpans[0]?.begin) ??
+                convertTimeToSeconds(bgSpan.begin) ??
+                bgVocal.Syllables[0]?.StartTime;
+              bgVocal.EndTime =
+                convertTimeToSeconds(bgVocalSpans[bgVocalSpans.length - 1]?.end) ??
+                convertTimeToSeconds(bgSpan.end) ??
+                bgVocal.Syllables[bgVocal.Syllables.length - 1]?.EndTime;
+
+              if (bgRoles.roman !== undefined && bgRoles.roman.trim() !== '') {
+                bgVocal.TransliteratedText = bgRoles.roman.trim();
+              }
+              if (bgRoles.translation !== undefined && bgRoles.translation.trim() !== '') {
+                bgVocal.TranslatedText = bgRoles.translation.trim();
+                bgVocal.HasTranslations = true;
+              }
+
+              if (
+                bgVocal.TransliteratedText !== undefined ||
+                bgVocal.Syllables.some((s) => s.TransliteratedText !== undefined)
+              ) {
+                bgVocal.HasTransliterations = true;
+              }
+
+              if (
+                bgVocal.Syllables.length === 0 &&
+                bgVocal.TransliteratedText === undefined &&
+                bgVocal.TranslatedText === undefined
+              ) {
+                return;
+              }
+
+              // Background vocals can start before, or run past, the lead line;
+              // the lead's window has to cover them or they get clipped.
+              if (
+                typeof bgVocal.EndTime === "number" &&
+                (vocal.Lead.EndTime === undefined || bgVocal.EndTime > vocal.Lead.EndTime)
+              ) {
+                vocal.Lead.EndTime = bgVocal.EndTime;
+              }
+
+              if (
+                typeof bgVocal.StartTime === "number" &&
+                (vocal.Lead.StartTime === undefined || bgVocal.StartTime < vocal.Lead.StartTime)
+              ) {
+                vocal.Lead.StartTime = bgVocal.StartTime;
+              }
+
+              backgrounds.push(bgVocal);
+            });
+
+            if (backgrounds.length > 0) vocal.Background = backgrounds;
+          }
+
+          const isEmpty =
+            vocal.Lead.Syllables.length === 0 &&
+            (vocal.Background === undefined || vocal.Background.length === 0) &&
+            vocal.Lead.TransliteratedText === undefined &&
+            vocal.Lead.TranslatedText === undefined;
+
+          if (isEmpty) {
+            skippedEmptyLines++;
+            return;
+          }
+
+          syllableLyrics.Content.push(vocal);
+        });
+      });
+
+      if (skippedEmptyLines > 0) {
+        ttmlLogger.debug(`Skipped ${skippedEmptyLines} empty syllable line(s)`);
+      }
+
+      if (syllableLyrics.StartTime === undefined) {
+        syllableLyrics.StartTime = syllableLyrics.Content[0]?.Lead?.StartTime;
+      }
+
+      // The last <p> is not necessarily the one that ends last.
+      let latestEnd: number | undefined;
+      for (const content of syllableLyrics.Content) {
+        const ends = [content.Lead?.EndTime, ...toArray(content.Background).map((bg) => bg?.EndTime)];
+        for (const end of ends) {
+          if (typeof end === 'number' && (latestEnd === undefined || end > latestEnd)) {
+            latestEnd = end;
+          }
+        }
+      }
+      syllableLyrics.EndTime = latestEnd;
+
+      lyricsJSON = syllableLyrics;
+      break;
+    }
+
+    default:
+      ttmlLogger.error(`Unsupported lyrics type: ${lyricsType}`);
+      return null;
+  }
+
+  const rootItems: ParsedRootItem[] =
+    lyricsJSON.Type === 'Static' ? lyricsJSON.Lines : lyricsJSON.Content;
+
+  if (rootItems.length === 0) {
+    ttmlLogger.warn('Conversion resulted in empty lyrics content');
+    return null;
+  }
+
+  const getLead = (item: ParsedRootItem): ParsedVocalGroup | undefined =>
+    'Lead' in item ? item.Lead : undefined;
+  const getBackground = (item: ParsedRootItem): ParsedVocalGroup[] | undefined =>
+    'Background' in item ? item.Background : undefined;
+  const getOwnTranslit = (item: ParsedRootItem): string | undefined =>
+    'TransliteratedText' in item ? item.TransliteratedText : undefined;
+  const getOwnTranslation = (item: ParsedRootItem): string | undefined =>
+    'TranslatedText' in item ? item.TranslatedText : undefined;
+
+  const anyTranslit = rootItems.some(
+    (item) =>
+      item?.HasTransliterations === true ||
+      getOwnTranslit(item) !== undefined ||
+      getLead(item)?.TransliteratedText !== undefined ||
+      getLead(item)?.Syllables?.some((s) => s?.TransliteratedText !== undefined) ||
+      getBackground(item)?.some((bg) => bg?.HasTransliterations || bg?.TransliteratedText !== undefined),
+  );
+  if (anyTranslit) lyricsJSON.HasTransliterations = true;
+  if (!lyricsJSON.HasTranslations) {
+    const anyTranslation = rootItems.some(
+      (item) =>
+        item?.HasTranslations === true ||
+        getOwnTranslation(item) !== undefined ||
+        getLead(item)?.TranslatedText !== undefined ||
+        getBackground(item)?.some((bg) => bg?.HasTranslations || bg?.TranslatedText !== undefined),
+    );
+    if (anyTranslation) lyricsJSON.HasTranslations = true;
+  }
+
+  ttmlLogger.info('Successfully converted lyrics');
+  return lyricsJSON;
+}
+
+const toFiniteSeconds = (value: number): number | undefined =>
+  Number.isFinite(value) && value >= 0 ? value : undefined;
+
+function convertTimeToSeconds(timeValue: TtmlTime | null | undefined): number | undefined {
+  if (timeValue == null) return undefined;
+
+  if (typeof timeValue === 'number') return toFiniteSeconds(timeValue);
+
+  const timeString = String(timeValue).trim();
+  if (timeString === '') return undefined;
+
+  // Clock time: [hh:]mm:ss[.fraction] — a 4th component is SMPTE frames, which
+  // needs ttp:frameRate to interpret, so it is dropped rather than guessed at.
+  if (timeString.includes(':')) {
+    const parts = timeString.split(':');
+    if (parts.length < 2 || parts.length > 4) {
+      ttmlLogger.debug('Unparseable clock time in TTML, ignoring', { timeString });
+      return undefined;
+    }
+
+    const reversed = parts.slice().reverse();
+    const offset = parts.length === 4 ? 1 : 0;
+
+    let seconds = 0;
+    for (let i = offset; i < reversed.length; i++) {
+      const part = parseFloat(reversed[i]);
+      if (!Number.isFinite(part)) {
+        ttmlLogger.debug('Unparseable clock time in TTML, ignoring', { timeString });
+        return undefined;
+      }
+      seconds += part * Math.pow(60, i - offset);
+    }
+
+    return toFiniteSeconds(seconds);
+  }
+
+  // Offset time: 12.5s / 300ms / 2m / 1.5h (and the unitless legacy form).
+  const match = /^([+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+))(ms|h|m|s|f|t)?$/.exec(timeString);
+  if (!match) {
+    ttmlLogger.debug('Unparseable time value in TTML, ignoring', { timeString });
+    return undefined;
+  }
+
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value)) return undefined;
+
+  switch (match[2]) {
+    case 'ms':
+      return toFiniteSeconds(value / 1000);
+    case 'h':
+      return toFiniteSeconds(value * 3600);
+    case 'm':
+      return toFiniteSeconds(value * 60);
+    case 's':
+    case undefined:
+      return toFiniteSeconds(value);
+    default:
+      // 'f' (frames) and 't' (ticks) need ttp:frameRate / ttp:tickRate.
+      ttmlLogger.debug('Unsupported TTML time metric, ignoring', { timeString });
+      return undefined;
+  }
+}
+
+function inferLyricsType(ttml: TtmlDocument): TTMLLyricsType {
+  const divs = getDivs(ttml);
+  let sawTiming = false;
+
+  for (const div of divs) {
+    if (!div || div.p == null) continue;
+    const ps = toArray(div.p);
+    for (const p of ps) {
+      if (!p || typeof p !== 'object') continue;
+      if (p.span) {
+        const spans = toArray(p.span);
+        const timedVocalSpans = spans.filter(
+          (s): s is TtmlSpan => isVocalSpan(s) && Boolean(s.begin),
+        );
+        if (timedVocalSpans.length > 1) return 'Syllable';
+        if (timedVocalSpans.length === 1) sawTiming = true;
+      }
+      if (p.begin) sawTiming = true;
+    }
+  }
+
+  return sawTiming ? 'Line' : 'Static';
+}
+
+function GetSongWriters(ttml: TtmlDocument): string[] | null {
+  ttmlLogger.debug('Getting songwriters from TTML');
+  const itm = ttml?.tt?.head?.metadata?.iTunesMetadata;
+  const itmetadata = Array.isArray(itm) ? itm.find(i => i?.songwriters) ?? itm[0] : itm;
+  const SongWriters = itmetadata?.songwriters?.songwriter;
+  if (!SongWriters) {
+    ttmlLogger.debug('No songwriters found in TTML');
+    return null;
+  }
+  const ProcessedSongWriters = toArray(SongWriters);
+
+  const SongWritersOutput = ProcessedSongWriters.map(SongWriter => {
+    if (SongWriter == null) return null;
+    const text = decodeXmlEntities(String(SongWriter)).trim();
+    return text === '' ? null : text;
+  }).filter((writer): writer is string => writer !== null);
+  if (SongWritersOutput.length === 0) {
+    ttmlLogger.debug("SongWriters - Not Found after mapping");
+    return null;
+  }
+  ttmlLogger.debug('Found songwriters:', SongWritersOutput);
+  return SongWritersOutput;
+}
+
+function GetTransliterations(ttml: TtmlDocument): TransliterationMap | null {
+  ttmlLogger.debug('Getting transliterations from TTML');
+  const itm = ttml?.tt?.head?.metadata?.iTunesMetadata;
+  if (!itm) return null;
+
+  const map: TransliterationMap = new Map();
+  let sawTransliterationNode = false;
+
+  // Some documents split metadata across several iTunesMetadata elements.
+  toArray(itm).forEach((metadata) => {
+    const transliteration = metadata?.transliterations?.transliteration;
+    if (!transliteration) return;
+    sawTransliterationNode = true;
+
+    toArray(transliteration).forEach((block) => {
+      toArray(block?.text).forEach((entry) => {
+        const lineKey = entry?.for;
+        if (!lineKey) return;
+
+        const line: TransliterationLine = { spans: [], background: [] };
+        collectTransliterationSpans(toArray(entry.span), line.spans, line.background);
+
+        if (line.spans.length === 0 && line.background.length === 0) return;
+
+        const existing = map.get(lineKey);
+        if (existing) {
+          existing.spans.push(...line.spans);
+          existing.background.push(...line.background);
+        } else {
+          map.set(lineKey, line);
+        }
+      });
+    });
+  });
+
+  if (!sawTransliterationNode) {
+    ttmlLogger.debug('No transliterations found in TTML');
+    return null;
+  }
+
+  if (map.size === 0) {
+    ttmlLogger.warn('Transliterations present but produced no usable spans');
+    return null;
+  }
+
+  ttmlLogger.debug(`Found transliterations for ${map.size} line(s)`);
+  return map;
+}
+
+/**
+ * Flattens a transliteration entry's spans. A timed span is a leaf; a span that
+ * holds children instead is a wrapper and has to be descended into — an
+ * `<span ttm:role="x-bg">` wrapper is exactly that, and silently dropping it
+ * (it carries no timings of its own) is what left background lines
+ * untransliterated. Its children are routed to the background list so they can
+ * never be mistaken for lead syllables.
+ */
+function collectTransliterationSpans(
+  nodes: TtmlSpanNode[],
+  out: TransliterationSpan[],
+  background: TransliterationSpan[],
+): void {
+  nodes.forEach((node) => {
+    if (!isSpanObject(node)) return;
+
+    const children = toArray(node.span);
+    if (children.length > 0) {
+      collectTransliterationSpans(
+        children,
+        node['ttm:role'] === 'x-bg' ? background : out,
+        background,
+      );
+      return;
+    }
+
+    if (node.begin == null || node.end == null) return;
+
+    out.push({
+      begin: node.begin,
+      end: node.end,
+      beginSeconds: convertTimeToSeconds(node.begin),
+      endSeconds: convertTimeToSeconds(node.end),
+      text: readText(node['#text']),
+    });
+  });
+}
+
+/**
+ * Background vocals are transliterated in one of two shapes: a dedicated
+ * <text for="..."> entry keyed off the x-bg span's own itunes:key, or — far
+ * more commonly — an x-bg wrapper nested inside the *line's* entry. Prefer
+ * whichever background list exists, then fall back to the lead spans, which is
+ * what legacy single-block documents rely on.
+ */
+function pickBackgroundTransliterations(
+  bgEntry: TransliterationLine | undefined,
+  lineEntry: TransliterationLine | undefined,
+): TransliterationSpan[] | undefined {
+  for (const entry of [bgEntry, lineEntry]) {
+    if (!entry) continue;
+    if (entry.background.length > 0) return entry.background;
+    if (entry.spans.length > 0) return entry.spans;
+  }
+  return undefined;
+}
+
+/** Timings can be written differently on both sides ("10.5s" vs "00:00:10.500"). */
+const TIME_MATCH_EPSILON = 0.002;
+
+function findTransliteratedText(
+  spans: TransliterationSpan[] | null | undefined,
+  begin: TtmlTime | undefined,
+  end: TtmlTime | undefined,
+): TransliterationSpan | undefined {
+  if (!Array.isArray(spans) || spans.length === 0) return undefined;
+  if (begin == null || end == null || begin === '' || end === '') return undefined;
+
+  const exact = spans.find((span) => span.begin === begin && span.end === end);
+  if (exact) return exact;
+
+  const beginSeconds = convertTimeToSeconds(begin);
+  const endSeconds = convertTimeToSeconds(end);
+  if (beginSeconds === undefined || endSeconds === undefined) return undefined;
+
+  return spans.find(
+    (span) =>
+      span.beginSeconds !== undefined &&
+      span.endSeconds !== undefined &&
+      Math.abs(span.beginSeconds - beginSeconds) <= TIME_MATCH_EPSILON &&
+      Math.abs(span.endSeconds - endSeconds) <= TIME_MATCH_EPSILON,
+  );
+}
+
+function getLineText(p: TtmlPNode | undefined): string | undefined {
+  if (p == null) return undefined;
+  if (typeof p === 'string') return decodeXmlEntities(p);
+  if (typeof p !== 'object') return readText(p);
+  if (p.span) {
+    const spans = toArray(p.span);
+    const mainTexts = spans
+      .filter((s) => typeof s === 'string' || isVocalSpan(s))
+      .map((s) => (typeof s === 'string' ? decodeXmlEntities(s) : readText(s['#text'])))
+      .filter((text) => text !== '');
+    if (mainTexts.length > 0) {
+      return mainTexts.reduce((acc, cur, i) => {
+        if (i === 0) return cur;
+        const needsSpace = !/\s$/.test(acc) && !/^\s/.test(cur);
+        return acc + (needsSpace ? ' ' : '') + cur;
+      }, '');
+    }
+  }
+  if (p['#text'] != null) return readText(p['#text']);
+  return undefined;
+}
+
+
+function extractRoleTexts(spans: TtmlSpanNode[]): RoleTexts {
+  const result: RoleTexts = { roman: undefined, translation: undefined };
+  if (!Array.isArray(spans)) return result;
+  spans.forEach((s) => {
+    if (!isSpanObject(s)) return;
+    const role = s['ttm:role'];
+    if (role === 'x-roman' && result.roman === undefined) {
+      result.roman = readText(s['#text']);
+    } else if (role === 'x-translation' && result.translation === undefined) {
+      result.translation = readText(s['#text']);
+    }
+  });
+  return result;
+}
+
+function getInlineRoleTexts(p: TtmlPNode | undefined): RoleTexts {
+  if (!p || typeof p !== 'object' || !p.span) return { roman: undefined, translation: undefined };
+  return extractRoleTexts(toArray(p.span));
+}
+
+export function GetLyricsType(ttmlXml: string): TTMLLyricsType | string | null {
+  ttmlLogger.debug('Getting lyrics type from TTML XML');
+
+  if (typeof ttmlXml !== 'string' || ttmlXml.trim() === '') {
+    ttmlLogger.warn('Cannot determine lyrics type: empty or non-string input');
+    return null;
+  }
+
+  let ttml: TtmlDocument;
+  try {
+    ttml = parser.parse(ttmlXml) as TtmlDocument;
+  } catch (parseError) {
+    ttmlLogger.error('Failed to parse TTML XML', (parseError as Error)?.message);
+    return null;
+  }
+
+  if (!ttml?.tt || typeof ttml.tt !== 'object') {
+    ttmlLogger.warn('Cannot determine lyrics type: parsed XML is not a TTML document');
+    return null;
+  }
+
+  const timing = ttml.tt['itunes:timing'];
+
+  if (timing === 'None') {
+    ttmlLogger.debug('Determined lyrics type: Static');
+    return 'Static';
+  } else if (timing === 'Word') {
+    ttmlLogger.debug('Determined lyrics type: Syllable');
+    return 'Syllable';
+  } else if (timing === undefined) {
+    const inferred = inferLyricsType(ttml);
+    ttmlLogger.debug(`No itunes:timing attribute, inferred lyrics type: ${inferred}`);
+    return inferred;
+  } else {
+    ttmlLogger.debug(`Determined lyrics type: ${timing}`);
+    return timing;
+  }
+}

--- a/src/utils/Scrolling/ScrollToActiveLine.ts
+++ b/src/utils/Scrolling/ScrollToActiveLine.ts
@@ -169,9 +169,30 @@ const GetScrollLine = (Lines: LyricsLine[] | LyricsSyllable[], ProcessedPosition
   const enhance = (index: number) =>
     ({ ...Lines[index], _LineIndex: index }) as EnhancedLyricsItem;
 
+  // 2) collapse the active lines onto their lead groups. A background line that
+  // still has another active group below it is only the tail of a line we have
+  // already moved past — a sustained "oooh" outliving its own lead — so it is
+  // dropped rather than dragging the anchor back up. A background line with
+  // nothing active below it is kept: it may be leading into its own line, which
+  // starts later than the background vocal does.
+  let frontLead = -1;
+  for (const index of activeIndices) {
+    const lead = ResolveToLeadIndex(Lines, index);
+    if (lead > frontLead) frontLead = lead;
+  }
+
+  // Ascending and deduplicated — ResolveToLeadIndex is monotonic over
+  // activeIndices, so only the previous entry needs checking.
+  const activeLeads: number[] = [];
+  for (const index of activeIndices) {
+    const lead = ResolveToLeadIndex(Lines, index);
+    if (IsBGLine(Lines[index]) && lead < frontLead) continue;
+    if (activeLeads[activeLeads.length - 1] !== lead) activeLeads.push(lead);
+  }
+
   // The highest active line keeps the anchor as long as it (and its background
   // lines) finish before the line PIN_LOOKAHEAD real lines further down starts.
-  const anchorIdx = ResolveToLeadIndex(Lines, activeIndices[0]);
+  const anchorIdx = activeLeads[0];
   const lookahead = GetLookaheadLine(Lines, anchorIdx);
   if (lookahead === null || GetGroupEndTime(Lines, anchorIdx) <= lookahead.StartTime) {
     return enhance(anchorIdx);
@@ -179,9 +200,9 @@ const GetScrollLine = (Lines: LyricsLine[] | LyricsSyllable[], ProcessedPosition
 
   // Anchor refused — fall back to the original heuristic: contiguous or off by
   // only 1 → the first active line, a bigger gap → the last.
-  const firstIdx = activeIndices[0];
-  const lastIdx = activeIndices[activeIndices.length - 1];
-  return enhance(ResolveToLeadIndex(Lines, lastIdx - firstIdx <= 1 ? firstIdx : lastIdx));
+  const firstIdx = activeLeads[0];
+  const lastIdx = activeLeads[activeLeads.length - 1];
+  return enhance(lastIdx - firstIdx <= 1 ? firstIdx : lastIdx);
 };
 
 const ScrollTo = (

--- a/src/utils/SessionManager/index.ts
+++ b/src/utils/SessionManager/index.ts
@@ -1,8 +1,14 @@
+import App from "../app.ts";
+import Logger from "../Logger.ts";
 import { SessionManager } from "./SessionManager.ts";
 
 export const sessionManager = new SessionManager();
 
 export async function initSession(): Promise<void> {
+  if (App.isDev()) {
+    new Logger("SessionManager").info("Dev build — skipping session creation");
+    return;
+  }
   await sessionManager.ensureSession();
 }
 

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -48,6 +48,14 @@ export const EXPERIMENTS = [
     default: true,
     pageClass: "Exp_NewProgressBar",
   },
+  {
+    id: "duetLinePadding",
+    label: "Duet Line Padding",
+    description:
+      "Indents lyrics lines on the side they lean away from when a song has duet lines, so the two voices read as separate columns. Disable to give every line the same slight padding.",
+    default: true,
+    pageClass: "Exp_DuetLinePadding",
+  },
 ] as const satisfies readonly Experiment[];
 
 /** A registry entry, narrowed to its literal `id` — what the UI iterates over. */

--- a/src/utils/openLyricsDBPanel.tsx
+++ b/src/utils/openLyricsDBPanel.tsx
@@ -40,6 +40,7 @@ function _openUpload() {
   });
 
   PopupModal.transition({
+    title: "Upload TTML",
     content: container,
     onClose: () => root.unmount(),
     closeHandler: _openDB,
@@ -55,6 +56,7 @@ function _openDB() {
   });
 
   PopupModal.transition({
+    title: "Local Lyrics DB",
     content: container,
     onClose: () => root.unmount(),
   });

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -86,6 +86,8 @@ export const $popupLyricsAllowed = (() => {
 })();
 export const $viewControlsPosition = persistAtom<string>("viewControlsPosition", "Top");
 export const $ttmlMakerMode = persistAtom<boolean>("ttmlMakerMode", true);
+// Last upload mode picked in the Local DB upload screen: "persistent" | "temporary".
+export const $ttmlUploadMode = persistAtom<string>("ttmlUploadMode", "persistent");
 export const $developerMode = persistAtom<boolean>("developerMode", false);
 export const $timelineOutsideMediaContent = persistAtom<boolean>(
   "timelineOutsideMediaContent",


### PR DESCRIPTION
# Update 6.3.10

## Features & Improvements
- Simplify Local TTML DB upload flow
- (experiment) Option to turn off duet-line line size reduction
- Currently Active Track is now placed on top of the list in the Local TTML DB
- Moved TTML parser for Local TTML DB to the client - your local TTMLs are now parsed locally without the need to hit our API

## Bugfixes
- **Fix for Spotify `>1.2.96` for requesting token**
- Fix background vocals not receiving romanization
- Fixed large empty space at the end of LyricsContainer
- Fixed emphasized words containing spaces from rendering such spaces with 0px width
- Bugfixes related to Lyrics and LyricsNotices