### PR TITLE
Fall back to player state when getPositionState stalls

### DIFF
--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -257,13 +257,21 @@ export const requestPositionSync = () => {
             localSourceHealth.LastChangeAt = sampledAt;
             localSourceHealth.ConsecutiveChanges = 0;
           }
+            if (
+              localSourceHealth.UsingState &&
+              localSourceHealth.ConsecutiveChanges >=
                 LOCAL_SOURCE_RECOVERY_STREAK
-              ) {
-                localSourceHealth.UsingState = false;
-              }
+            ) {
+              localSourceHealth.UsingState = false;
             } else if (stalled) {
               localSourceHealth.UsingState = true;
             }
+          } else if (localSourceHealth) {
+            // Paused playback can legitimately hold getPositionState. Reset the
+            // observation window so paused time does not count as a stall, while
+            // preserving the active source choice across the pause.
+            localSourceHealth.LastChangeAt = sampledAt;
+            localSourceHealth.ConsecutiveChanges = 0;
           }
           // A pause legitimately freezes getPositionState, so health is only
           // judged while playing — but the verdict carries across the pause.

--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -22,6 +22,19 @@ let lastLocalSample: {
   SampledAt: number;
   TrackUri: string | null;
 } | null = null;
+// Whether getPositionState is actually refreshing on this client. Some builds
+// only move it when the player emits a state change and otherwise return the
+// same number for tens of seconds; on one measured client it went 72s without
+// moving. See pickLocalSource.
+// The previous poll's raw getPositionState reading. Tracked separately from the
+// anchor because the anchor may hold a state-derived value, and "did the source
+// move?" must stay a comparison between two readings of the same source.
+let lastRawLocalSample: number | null = null;
+let localSourceHealth: {
+  LastChangeAt: number;
+  ConsecutiveChanges: number;
+  UsingState: boolean;
+} | null = null;
 // Previous poll's reading of the player state, used only to spot a
 // discontinuity (seek/track change) in the state itself. See getLocalPosition.
 let lastStateReading: {
@@ -50,6 +63,17 @@ const JITTER_TIME_CONSTANT = 300;
 // Sits above a deliberate seek (>=1s) so ordinary state-update noise never
 // discards a healthy anchor.
 const LOCAL_ANCHOR_RESYNC_THRESHOLD = 1000;
+// How long getPositionState may return the same value while playing (ms) before
+// the source counts as stalled and the clock switches to the player state. A
+// client that refreshes it normally produces a new value every poll (~16ms), so
+// this only trips on a source that has genuinely stopped.
+const LOCAL_SOURCE_STALL_TIMEOUT = 500;
+// Consecutive polls with a *new* getPositionState value required to hand the
+// clock back to it. The two sources sit tens to hundreds of ms apart, so every
+// switch between them is a step the jitter filter then glides over — visible as
+// wobble. Hysteresis is what stops a source that moves once every few seconds
+// from causing that step each time it twitches.
+const LOCAL_SOURCE_RECOVERY_STREAK = 3;
 
 function clampToTrack(position: number): number {
   const duration = SpotifyPlayer.GetDuration();
@@ -183,6 +207,78 @@ export const requestPositionSync = () => {
               Position: stateReading,
               ReadAt: sampledAt,
               WasPlaying: isPlaying,
+            };
+          }
+
+          const rawChangedSinceLastPoll = lastRawLocalSample !== sampled;
+          lastRawLocalSample = sampled;
+
+          // Decide which source drives the clock this poll.
+          //
+          // getPositionState is the audio-side truth when it moves, so it stays
+          // the default. But when it stops moving, holding its last value can
+          // only extrapolate through the gap — it cannot correct a value that
+          // was already stale when it arrived (a seek or track change landing
+          // mid-stall), and that error then persists for the whole stall.
+          //
+          // The player state has no such failure mode: it is timestamped, so
+          // extrapolating it stays correct however rarely it is read. That is why
+          // it is the sole source in the non-local branch, and the fallback here.
+          //
+          // The switch is deliberately sticky. The two sources sit tens to
+          // hundreds of ms apart, so each handover is a step discontinuity that
+          // the jitter filter smooths into a visible glide. Requiring a run of
+          // genuinely fresh samples before handing the clock back keeps a source
+          // that twitches once every few seconds from stepping the clock each
+          // time. A client that refreshes normally satisfies the streak on its
+          // first polls and never leaves getPositionState.
+          if (isPlaying) {
+            const changed = rawChangedSinceLastPoll;
+            if (!localSourceHealth) {
+              localSourceHealth = {
+                LastChangeAt: sampledAt,
+                ConsecutiveChanges: changed ? 1 : 0,
+                UsingState: false,
+              };
+            } else {
+              localSourceHealth.ConsecutiveChanges = changed
+                ? localSourceHealth.ConsecutiveChanges + 1
+                : 0;
+              if (changed) localSourceHealth.LastChangeAt = sampledAt;
+            }
+
+            const stalled =
+              sampledAt - localSourceHealth.LastChangeAt >
+              LOCAL_SOURCE_STALL_TIMEOUT;
+            if (localSourceHealth.UsingState) {
+              if (
+                localSourceHealth.ConsecutiveChanges >=
+                LOCAL_SOURCE_RECOVERY_STREAK
+              ) {
+                localSourceHealth.UsingState = false;
+              }
+            } else if (stalled) {
+              localSourceHealth.UsingState = true;
+            }
+          }
+          // A pause legitimately freezes getPositionState, so health is only
+          // judged while playing — but the verdict carries across the pause.
+
+          if (
+            localSourceHealth?.UsingState &&
+            isPlaying &&
+            Number.isFinite(stateReading)
+          ) {
+            // The state is live and self-extrapolating, so re-anchor every poll:
+            // there is no stall to hold through, and holding would only add lag.
+            lastLocalSample = {
+              Position: stateReading,
+              SampledAt: sampledAt,
+              TrackUri: trackUri,
+            };
+            return {
+              StartedSyncAt: sampledAt,
+              Position: stateReading,
             };
           }
 

--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -250,9 +250,13 @@ export const requestPositionSync = () => {
             const stalled =
               sampledAt - localSourceHealth.LastChangeAt >
               LOCAL_SOURCE_STALL_TIMEOUT;
-            if (localSourceHealth.UsingState) {
-              if (
-                localSourceHealth.ConsecutiveChanges >=
+          } else if (localSourceHealth) {
+            // Paused playback can legitimately hold getPositionState. Reset the
+            // observation window so paused time does not count as a stall, while
+            // preserving the active source choice across the pause.
+            localSourceHealth.LastChangeAt = sampledAt;
+            localSourceHealth.ConsecutiveChanges = 0;
+          }
                 LOCAL_SOURCE_RECOVERY_STREAK
               ) {
                 localSourceHealth.UsingState = false;

--- a/src/utils/expose.ts
+++ b/src/utils/expose.ts
@@ -6,6 +6,7 @@ import { OpenLyricsDBPanel } from "./openLyricsDBPanel";
 import { DeepFreeze } from "./utils";
 import { triggerSpicyLyricsFakeUpdate } from "./version/CheckForUpdates";
 import { BreakerDebug } from "./API/CircuitBreaker";
+import GetProgress from "./Gets/GetProgress";
 
 export function exposeToWindow() {
     const api = {
@@ -33,6 +34,10 @@ export function exposeToWindow() {
             // Escape hatch: a bad persisted breaker state would otherwise mean
             // telling users to clear localStorage by hand.
             breaker: BreakerDebug,
+            // The clock the lyrics renderer runs on. Exposed because playback
+            // desync can only be diagnosed by sampling this against the player
+            // state from the console; nothing else reaches it.
+            getProgress: () => GetProgress(),
         }
     };
 


### PR DESCRIPTION
TL;DR: made it notice when the number stops changing then uses Spotify's other timestamped position instead, as that one can't get stuck, if you wanna read, enjoy.


### The problem

On some clients `PlayerAPI._contextPlayer.getPositionState()` only refreshes when the player emits a state change. Between those events it returns the same value for as long as tens of seconds. Sampled at 10 Hz on an affected Windows client, it returned an identical position for **72 seconds** while playback continued normally:

| wall clock | `getPositionState` | `_state` extrapolated |
| --- | --- | --- |
| t+0s | 43011 | 56298 |
| t+30s | 43011 | 86793 |
| t+60s | 43011 | 115801 |

`getLocalPosition` already holds the anchor from when a value *first* appeared, so the clock extrapolates through a stall rather than freezing with it. But holding cannot correct a value that was **already stale when it arrived**. If a seek or track change lands mid-stall, the anchor is wrong from the moment it is taken and stays wrong for the remainder of the stall. Measured worst case on the same client: the clock read `20789` where the audio was at `57072` — **36 seconds adrift**, and it only recovered when the source happened to move again.

This is what produced desynced lyrics on seeking, and on unfocusing Spotify. The unfocus case is the same bug: background throttling stretches the polling gaps far enough that a track change lands inside one.

The existing jump detector does not catch it. It requires `lastStateReading?.WasPlaying && isPlaying`, and a seek reports `isPlaying === false` for a poll or two; the next poll rebuilds its expectation from post-jump values, so the jump never registers.

### The change

Track whether the source is refreshing. Once it has repeated a value for more than 500 ms while playing, drive the clock from `PlayerAPI._state` instead. The state is timestamped, so extrapolating it stays correct however rarely it is read — which is why `getNonLocalPosition` already runs on it alone.

Hand the clock back only after three consecutive fresh samples. The two sources sit tens to hundreds of ms apart (measured −33 ms to −349 ms on the affected client), so every switch between them is a step that `normalizeProgress` then glides over with its 300 ms time constant — visible as wobble. Without hysteresis, a source that twitches once every few seconds steps the clock each time it does.

A client that refreshes normally produces a new value every poll, satisfies the streak on its first polls, and never leaves `getPositionState`. That path is unchanged, including the Linux jitter handling from 78993f9 and the stale-anchor detection from 6da50b0.

### What is and isn't verified

The mechanism is measured: the 72 s stall, the 36 s error, and the inter-source offsets above all come from logged samples on the affected machine. The fix itself is confirmed by observation on that one machine — I did not capture a before/after measurement of the resulting clock error, and I have no second affected client to test against. The unaffected path is argued from the code rather than measured, since the branch is only reachable on a client whose source stalls.

### Also included

`GetProgress` is exposed as `SpicyLyrics.testing.getProgress()`. The clock was unreachable from the console, so this class of desync could only be inferred from its inputs rather than measured directly. Happy to drop this from the PR if you'd rather keep it out.
